### PR TITLE
MSTR-50 : 문제 리스트 페이지의 필터에 태그 리스트가 보여진다.

### DIFF
--- a/src/Component/Tag/index.tsx
+++ b/src/Component/Tag/index.tsx
@@ -2,7 +2,11 @@
 
 import { css } from '@emotion/react';
 
-function Tag(name: string) {
+interface TTag {
+  name: string;
+}
+
+function Tag({ name }: TTag) {
   return <li css={tagStyle}>{name}</li>;
 }
 

--- a/src/Component/Tag/index.tsx
+++ b/src/Component/Tag/index.tsx
@@ -2,11 +2,11 @@
 
 import { css } from '@emotion/react';
 
-interface TTag {
+interface ITag {
   name: string;
 }
 
-function Tag({ name }: TTag) {
+function Tag({ name }: ITag) {
   return <li css={tagStyle}>{name}</li>;
 }
 

--- a/src/Component/Tag/index.tsx
+++ b/src/Component/Tag/index.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+
+function Tag(name: string) {
+  return <li css={tagStyle}>{name}</li>;
+}
+
+const tagStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 50px;
+  height: 25px;
+
+  background: #fff1cd;
+  border-radius: 10px;
+
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: inherit;
+
+  text-align: center;
+`;
+
+export default Tag;

--- a/src/Component/Tag/index.tsx
+++ b/src/Component/Tag/index.tsx
@@ -15,7 +15,7 @@ const tagStyle = css`
   align-items: center;
   justify-content: center;
 
-  width: 50px;
+  width: 70px;
   height: 25px;
 
   background: #fff1cd;

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -12,7 +12,7 @@ function DropdownElement({ id, name, checkedItemHandler }: IDropdownComponentPro
   const [isChecked, setIsChecked] = useState(false);
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
     setIsChecked(!isChecked);
-    checkedItemHandler(target.id, target.checked);
+    checkedItemHandler(target.name, target.checked);
   }
 
   return (

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -5,14 +5,15 @@ import { ChangeEvent, useState } from 'react';
 import { IDropdownElement } from '../../../types';
 
 interface IDropdownComponentProps extends IDropdownElement {
-  checkedItemHandler: (id: string, isChecked: boolean) => void;
+  handleCheckedTags: (name: string, isChecked: boolean) => void;
 }
 
-function DropdownElement({ id, name, checkedItemHandler }: IDropdownComponentProps) {
+function DropdownElement({ id, name, handleCheckedTags }: IDropdownComponentProps) {
   const [isChecked, setIsChecked] = useState(false);
+
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
     setIsChecked(!isChecked);
-    checkedItemHandler(target.name, target.checked);
+    handleCheckedTags(target.name, target.checked);
   }
 
   return (

--- a/src/Component/Utils/Dropdown/index.tsx
+++ b/src/Component/Utils/Dropdown/index.tsx
@@ -9,14 +9,14 @@ import { IDropdownElement } from '../../../types';
 
 interface ITagType {
   name: string;
-  type: IDropdownElement[];
+  elements: IDropdownElement[];
 }
 
 interface IDropdownProps extends ITagType {
   handleCheckedTags: (name: string, isChecked: boolean) => void;
 }
 
-function Dropdown({ name, type, handleCheckedTags }: IDropdownProps) {
+function Dropdown({ name, elements, handleCheckedTags }: IDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -34,7 +34,7 @@ function Dropdown({ name, type, handleCheckedTags }: IDropdownProps) {
       </button>
       <div css={dropDownContentStyle(isOpen)}>
         <ul>
-          {type.map((e) => (
+          {elements.map((e) => (
             <DropdownElement
               id={e.id}
               name={e.name}

--- a/src/Component/Utils/Dropdown/index.tsx
+++ b/src/Component/Utils/Dropdown/index.tsx
@@ -12,21 +12,16 @@ interface ITagType {
   type: IDropdownElement[];
 }
 
-function Dropdown(tagType: ITagType) {
+interface IDropdownProps extends ITagType {
+  checkedItemHandler: (name: string, isChecked: boolean) => void;
+}
+
+function Dropdown({ name, type, checkedItemHandler }: IDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [checkedItems, setCheckedItems] = useState(new Set<string>());
   const menuRef = useRef<HTMLDivElement>(null);
 
   function onClickDropdown() {
     setIsOpen(!isOpen);
-  }
-
-  function checkedItemHandler(id: string, isChecked: boolean) {
-    if (isChecked) {
-      setCheckedItems((prev) => new Set([...prev, id]));
-    } else {
-      setCheckedItems((prev) => new Set([...prev].filter((currId) => currId !== id)));
-    }
   }
 
   useEffect(listenOutsideClick(menuRef, setIsOpen), []);
@@ -34,12 +29,12 @@ function Dropdown(tagType: ITagType) {
   return (
     <div css={dropDownStyle} ref={menuRef}>
       <button css={dropdownBoxStyle} onClick={onClickDropdown} type="button">
-        <p>{tagType.name} 선택</p>
+        <p>{name} 선택</p>
         <DownIcon />
       </button>
       <div css={dropDownContentStyle(isOpen)}>
         <ul>
-          {tagType.type.map((e) => (
+          {type.map((e) => (
             <DropdownElement
               id={e.id}
               name={e.name}

--- a/src/Component/Utils/Dropdown/index.tsx
+++ b/src/Component/Utils/Dropdown/index.tsx
@@ -13,10 +13,10 @@ interface ITagType {
 }
 
 interface IDropdownProps extends ITagType {
-  checkedItemHandler: (name: string, isChecked: boolean) => void;
+  handleCheckedTags: (name: string, isChecked: boolean) => void;
 }
 
-function Dropdown({ name, type, checkedItemHandler }: IDropdownProps) {
+function Dropdown({ name, type, handleCheckedTags }: IDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -38,7 +38,7 @@ function Dropdown({ name, type, checkedItemHandler }: IDropdownProps) {
             <DropdownElement
               id={e.id}
               name={e.name}
-              checkedItemHandler={checkedItemHandler}
+              handleCheckedTags={handleCheckedTags}
               key={`${e.id}${e.name}`}
             />
           ))}

--- a/src/Page/QuestionListPage.tsx
+++ b/src/Page/QuestionListPage.tsx
@@ -1,16 +1,27 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
+import { useState } from 'react';
 import SearchInputBox from '../Component/Box/InputBox/SearchInputBox';
 import TextBox from '../Component/Box/TextBox';
+import Tag from '../Component/Tag';
 import Dropdown from '../Component/Utils/Dropdown';
 import Slider from '../Component/Utils/Slider';
-import { TAGLIST, TAGTYPELIST } from '../constants';
+import { TAGLIST } from '../constants';
 import { listData } from '../data';
 import Header from '../Template/Header';
 import { IQuetionListElement } from '../types';
 
 function QuestionListPage() {
+  const [checkedItems, setCheckedItems] = useState(new Set<string>());
+
+  function checkedItemHandler(name: string, isChecked: boolean) {
+    if (isChecked) {
+      setCheckedItems((prev) => new Set([...prev, name]));
+    } else {
+      setCheckedItems((prev) => new Set([...prev].filter((currId) => currId !== name)));
+    }
+  }
   return (
     <>
       <Header />
@@ -21,10 +32,20 @@ function QuestionListPage() {
           <div css={filterStyle}>
             <div css={filterTitleStyle}>필터</div>
             <div css={dropdownListStyle}>
-              {TAGTYPELIST.map((tagtype) => (
-                <Dropdown {...TAGLIST[tagtype]} key={tagtype} />
+              {TAGLIST.map((tagtype) => (
+                <Dropdown
+                  name={tagtype.name}
+                  type={tagtype.type}
+                  checkedItemHandler={checkedItemHandler}
+                  key={tagtype.name}
+                />
               ))}
             </div>
+            <ul>
+              {/* {[...checkedItems].map((tagName) => (
+                <Tag name={tagName} key={tagName} />
+              ))} */}
+            </ul>
           </div>
         </aside>
 

--- a/src/Page/QuestionListPage.tsx
+++ b/src/Page/QuestionListPage.tsx
@@ -16,10 +16,6 @@ import { IQuetionListElement } from '../types';
 function QuestionListPage() {
   const { checkedTags, handleCheckedTags } = useStore();
 
-  // useEffect(() => {
-  //   console.log(checkedTags);
-  // });
-
   return (
     <>
       <Header />
@@ -39,7 +35,7 @@ function QuestionListPage() {
                 />
               ))}
             </div>
-            <ul>
+            <ul css={checkedTagListStyle}>
               {[...checkedTags].map((tagName) => (
                 <Tag name={tagName} key={tagName} />
               ))}
@@ -69,7 +65,10 @@ const pageMainStyle = css`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  width: 100%;
   height: 100%;
+
   padding: 40px;
 `;
 
@@ -78,6 +77,8 @@ const asideStyle = css`
   display: flex;
   flex-direction: column;
   gap: 20px;
+
+  width: 100%;
 
   left: 3%;
   top: 35%;
@@ -88,6 +89,7 @@ const filterStyle = css`
   flex-direction: column;
   gap: 20px;
 
+  width: 284px;
   height: fit-content;
 
   background: #f5f5f5;
@@ -115,6 +117,14 @@ const dropdownListStyle = css`
   @media screen and (max-width: 600px) {
     flex-direction: row;
   }
+`;
+
+const checkedTagListStyle = css`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20vw, 1fr));
+  grid-gap: 1rem;
+
+  /* width: 50%; */
 `;
 
 const questionListStyle = css`

--- a/src/Page/QuestionListPage.tsx
+++ b/src/Page/QuestionListPage.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
 import SearchInputBox from '../Component/Box/InputBox/SearchInputBox';
 import TextBox from '../Component/Box/TextBox';
 import Tag from '../Component/Tag';
@@ -29,7 +28,7 @@ function QuestionListPage() {
               {TAGLIST.map((tagtype) => (
                 <Dropdown
                   name={tagtype.name}
-                  type={tagtype.type}
+                  elements={tagtype.elements}
                   handleCheckedTags={handleCheckedTags}
                   key={tagtype.name}
                 />

--- a/src/Page/QuestionListPage.tsx
+++ b/src/Page/QuestionListPage.tsx
@@ -120,10 +120,11 @@ const dropdownListStyle = css`
 
 const checkedTagListStyle = css`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(20vw, 1fr));
-  grid-gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  grid-gap: 10px;
 
-  /* width: 50%; */
+  width: 50%;
+  align-self: center;
 `;
 
 const questionListStyle = css`

--- a/src/Page/QuestionListPage.tsx
+++ b/src/Page/QuestionListPage.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import SearchInputBox from '../Component/Box/InputBox/SearchInputBox';
 import TextBox from '../Component/Box/TextBox';
 import Tag from '../Component/Tag';
@@ -9,19 +9,17 @@ import Dropdown from '../Component/Utils/Dropdown';
 import Slider from '../Component/Utils/Slider';
 import { TAGLIST } from '../constants';
 import { listData } from '../data';
+import useStore from '../hooks/useStore';
 import Header from '../Template/Header';
 import { IQuetionListElement } from '../types';
 
 function QuestionListPage() {
-  const [checkedItems, setCheckedItems] = useState(new Set<string>());
+  const { checkedTags, handleCheckedTags } = useStore();
 
-  function checkedItemHandler(name: string, isChecked: boolean) {
-    if (isChecked) {
-      setCheckedItems((prev) => new Set([...prev, name]));
-    } else {
-      setCheckedItems((prev) => new Set([...prev].filter((currId) => currId !== name)));
-    }
-  }
+  // useEffect(() => {
+  //   console.log(checkedTags);
+  // });
+
   return (
     <>
       <Header />
@@ -36,15 +34,15 @@ function QuestionListPage() {
                 <Dropdown
                   name={tagtype.name}
                   type={tagtype.type}
-                  checkedItemHandler={checkedItemHandler}
+                  handleCheckedTags={handleCheckedTags}
                   key={tagtype.name}
                 />
               ))}
             </div>
             <ul>
-              {/* {[...checkedItems].map((tagName) => (
+              {[...checkedTags].map((tagName) => (
                 <Tag name={tagName} key={tagName} />
-              ))} */}
+              ))}
             </ul>
           </div>
         </aside>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { TAGLIST, TAGTYPELIST } from './tag';
+import { TAGLIST } from './tag';
 import { EVENT } from './event';
 
-export { TAGLIST, TAGTYPELIST, EVENT };
+export { TAGLIST, EVENT };

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -48,6 +48,4 @@ const TAGLIST = [
   },
 ];
 
-const TAGTYPELIST = ['category', 'isSolved', 'problemKit'] as const;
-
 export { TAGLIST };

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,5 +1,5 @@
-const TAGLIST = {
-  category: {
+const TAGLIST = [
+  {
     name: '카테고리',
     type: [
       {
@@ -20,7 +20,7 @@ const TAGLIST = {
       },
     ],
   },
-  isSolved: {
+  {
     name: '풀이 여부',
     type: [
       {
@@ -33,7 +33,7 @@ const TAGLIST = {
       },
     ],
   },
-  problemKit: {
+  {
     name: '문제 kit',
     type: [
       {
@@ -50,7 +50,7 @@ const TAGLIST = {
       },
     ],
   },
-};
+];
 
 const TAGTYPELIST = ['category', 'isSolved', 'problemKit'] as const;
 

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,7 +1,7 @@
 const TAGLIST = [
   {
     name: '카테고리',
-    type: [
+    elements: [
       {
         id: 'nt',
         name: '네트워크',
@@ -22,7 +22,7 @@ const TAGLIST = [
   },
   {
     name: '풀이 여부',
-    type: [
+    elements: [
       {
         id: 'solved',
         name: '푼 문제',
@@ -35,13 +35,13 @@ const TAGLIST = [
   },
   {
     name: '채점 가능 여부',
-    type: [
+    elements: [
       {
-        id: 'grade-able',
+        id: 'gradeable',
         name: '채점 가능',
       },
       {
-        id: 'grade-unable',
+        id: 'ungradable',
         name: '채점 불가능',
       },
     ],
@@ -50,4 +50,4 @@ const TAGLIST = [
 
 const TAGTYPELIST = ['category', 'isSolved', 'problemKit'] as const;
 
-export { TAGLIST, TAGTYPELIST };
+export { TAGLIST };

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -24,29 +24,25 @@ const TAGLIST = [
     name: '풀이 여부',
     type: [
       {
-        id: 'true',
+        id: 'solved',
         name: '푼 문제',
       },
       {
-        id: 'false',
+        id: 'unsolved',
         name: '안 푼 문제',
       },
     ],
   },
   {
-    name: '문제 kit',
+    name: '채점 가능 여부',
     type: [
       {
-        id: 'ds-1',
-        name: '자료구조 완벽정리 1',
+        id: 'grade-able',
+        name: '채점 가능',
       },
       {
-        id: 'ds-2',
-        name: '자료구조 완벽정리 2',
-      },
-      {
-        id: 'ds-3',
-        name: '자료구조 완벽정리 3',
+        id: 'grade-unable',
+        name: '채점 불가능',
       },
     ],
   },

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -5,10 +5,6 @@ interface ICheckedTags {
   handleCheckedTags: (name: string, isChecked: boolean) => void;
 }
 
-// interface IStore extends ICheckedTags{
-//     id: string;
-// }
-
 const useStore = create<ICheckedTags>((set) => ({
   checkedTags: new Set<string>(),
   handleCheckedTags: (name: string, isChecked: boolean) =>

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -1,0 +1,22 @@
+import create from 'zustand';
+
+interface ICheckedTags {
+  checkedTags: Set<string>;
+  handleCheckedTags: (name: string, isChecked: boolean) => void;
+}
+
+// interface IStore extends ICheckedTags{
+//     id: string;
+// }
+
+const useStore = create<ICheckedTags>((set) => ({
+  checkedTags: new Set<string>(),
+  handleCheckedTags: (name: string, isChecked: boolean) =>
+    set((state: ICheckedTags) => ({
+      checkedTags: isChecked
+        ? new Set([...state.checkedTags, name])
+        : new Set([...state.checkedTags].filter((curName) => curName !== name)),
+    })),
+}));
+
+export default useStore;

--- a/src/reset.css
+++ b/src/reset.css
@@ -39,6 +39,7 @@ ol li {
 ol,
 ul,
 li {
+  list-style: none;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/63906230/177522661-4890bb2e-78dd-4ce3-afa3-9bdc5431cee2.gif)

- 필터에서 선택한 태그 리스트가 보여짐

## 궁금한 점
- 문제가 250개 밖에 없다는 점에서 프론트단에서 태그에 따른 문제 필터링을 하는 것이 더 효율적일지? 아니면 백엔드에 요청을 보내서 리스트를 매번 받는게 나을지 고민입니다.