### PR TITLE
MSTR-166: 객관식, 단답형 페이지

### DIFF
--- a/src/Page/QuestionDetailPage/Long/index.tsx
+++ b/src/Page/QuestionDetailPage/Long/index.tsx
@@ -1,0 +1,148 @@
+import Header from '../../../Template/Header';
+import Split from 'react-split';
+import {
+  themeLightClass,
+  pageStyle,
+  topStyle,
+  descStyle,
+  titleTagStyle,
+  questionContentStyle,
+  splitStyle,
+  contentWrapperStyle,
+  contentTitleStyle,
+  problemDescContentStyle,
+  buttonListStyle,
+  themeDarkClass,
+  answerInputContentStyle,
+  tagListStyle,
+} from './style.css';
+import '../gutter.css';
+import { Link, useParams } from 'react-router-dom';
+import Tag from '../../../Component/Box/TagBox';
+import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../../types/button';
+import TextButton from '../../../Component/Button/TextButton';
+import { ReactComponent as SunIcon } from '../../../assets/icons/sun.svg';
+import { ReactComponent as MoonIcon } from '../../../assets/icons/moon.svg';
+import { useAuthStore } from '../../../hooks/useStore';
+import { useEffect, useState } from 'react';
+import baseFontStyle from '../../../styles/font.css';
+import { problemApiWrapper } from '../../../api/wrapper/problem/problemApiWrapper';
+import { URL, URLWithParam } from '../../../constants/url';
+import { IProblemDetailResponseData } from '../../../types/api/problem';
+
+export function LongQuestionDetailPage() {
+  const { id } = useParams();
+  const { isLogin } = useAuthStore();
+  const [data, setData] = useState<IProblemDetailResponseData>();
+
+  const [isDark, setIsDark] = useState(true);
+
+  function toggleDarkMode() {
+    setIsDark((prev) => !prev);
+  }
+
+  function handleSubmit() {
+    return;
+  }
+
+  useEffect(() => {
+    if (!id) return;
+    problemApiWrapper.problemDetail(id).then((res) => {
+      setData(res.data);
+    });
+  }, []);
+
+  return (
+    <div>
+      {data ? (
+        <>
+          <Header />
+          <main className={`${isDark ? themeDarkClass : themeLightClass} ${pageStyle}`}>
+            <div className={topStyle}>
+              <div className={descStyle}>
+                <div className={titleTagStyle}>
+                  <h1 className={baseFontStyle.title}>{data?.title}</h1>
+                  <ul className={tagListStyle}>
+                    {data?.tags.map((tagId) => (
+                      <Tag tagId={tagId} key={tagId} />
+                    ))}
+                  </ul>
+                </div>
+                <div className={baseFontStyle.medium}>
+                  {`제출 : ${data?.totalSolved ?? 0}, 평균 점수 : ${
+                    data?.avgScore ?? 0
+                  }점, 최고점 : ${data?.topScore ?? 0}점 , 최저점 : ${data?.bottomScore ?? 0}점`}
+                </div>
+              </div>
+
+              <button onClick={toggleDarkMode}>{isDark ? <MoonIcon /> : <SunIcon />}</button>
+            </div>
+            <div className={questionContentStyle}>
+              <Split
+                sizes={[25, 75]}
+                minSize={100}
+                expandToMin={false}
+                gutterSize={10}
+                gutterAlign='center'
+                snapOffset={30}
+                dragInterval={1}
+                direction='horizontal'
+                cursor='col-resize'
+                className={splitStyle}
+              >
+                <div className={contentWrapperStyle}>
+                  <div className={contentTitleStyle}>문제 설명</div>
+                  <div className={problemDescContentStyle}>{data?.description}</div>
+                </div>
+                <div className={contentWrapperStyle}>
+                  <label htmlFor='answer' className={contentTitleStyle}>
+                    답안 작성
+                  </label>
+                  <textarea
+                    id='answer'
+                    placeholder='답변을 입력해주세요'
+                    className={answerInputContentStyle}
+                  ></textarea>
+                </div>
+              </Split>
+            </div>
+
+            <div className={buttonListStyle}>
+              {isLogin ? (
+                <Link to={URLWithParam.LONG_PROBLEM_RESULT(id!)}>
+                  <TextButton
+                    type={BUTTON_TYPE.SUBMIT}
+                    theme={BUTTON_THEME.PRIMARY}
+                    size={BUTTON_SIZE.MEDIUM}
+                    onClick={handleSubmit}
+                  >
+                    제출하기
+                  </TextButton>
+                </Link>
+              ) : (
+                <TextButton
+                  type={BUTTON_TYPE.SUBMIT}
+                  theme={BUTTON_THEME.PRIMARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                >
+                  로그인
+                </TextButton>
+              )}
+              <Link to={URL.PROBLEM_LIST}>
+                <TextButton
+                  type={BUTTON_TYPE.BUTTON}
+                  theme={BUTTON_THEME.SECONDARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                >
+                  돌아가기
+                </TextButton>
+              </Link>
+            </div>
+          </main>
+        </>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+}

--- a/src/Page/QuestionDetailPage/Long/style.css.ts
+++ b/src/Page/QuestionDetailPage/Long/style.css.ts
@@ -1,0 +1,142 @@
+import { createThemeContract, createTheme, style, keyframes } from '@vanilla-extract/css';
+import { COLOR } from '../../../constants/color';
+import baseFontStyle from '../../../styles/font.css';
+
+export const vars = createThemeContract({
+  backgroundColor: null,
+  contentBackgroundColor: null,
+  textColor: null,
+});
+
+export const themeLightClass = createTheme(vars, {
+  backgroundColor: COLOR.WHITE,
+  contentBackgroundColor: COLOR.OFFWHITE,
+  textColor: COLOR.TITLEACTIVE,
+});
+
+export const themeDarkClass = createTheme(vars, {
+  backgroundColor: COLOR.TITLEACTIVE,
+  contentBackgroundColor: COLOR.DARKGRAY,
+  textColor: COLOR.WHITE,
+});
+
+const spread = keyframes({
+  '0%': { backgroundColor: 'inherit' },
+  '100%': { backgroundColor: vars.backgroundColor },
+});
+
+export const pageStyle = style({
+  boxSizing: 'border-box',
+
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-start',
+  alignItems: 'stretch',
+  gap: '1.5rem',
+
+  width: '100%',
+
+  color: vars.textColor,
+  backgroundColor: vars.backgroundColor,
+
+  transition: 'background-color 0.2s',
+  animation: spread,
+  padding: '3rem',
+});
+
+export const topStyle = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+
+  width: '100%',
+});
+
+export const descStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  justifyContent: 'center',
+});
+
+export const titleTagStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.5rem',
+});
+
+export const questionContentStyle = style({
+  display: 'flex',
+  height: '60vh',
+  background: vars.contentBackgroundColor,
+  padding: ' 0 1.5rem',
+  borderRadius: '10px',
+});
+
+export const splitStyle = style({
+  display: 'flex',
+  width: '100%',
+});
+
+export const contentWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  gap: '2rem',
+
+  padding: '1.5rem 0',
+});
+
+export const contentTitleStyle = style([
+  baseFontStyle.xlarge,
+  {
+    color: vars.textColor,
+  },
+]);
+
+export const problemDescContentStyle = style([
+  baseFontStyle.small,
+  {
+    overflowY: 'scroll',
+    color: vars.textColor,
+  },
+]);
+
+export const questionDescStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  gap: '2.5rem',
+});
+
+export const answerInputStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const answerInputContentStyle = style({
+  display: 'flex',
+
+  width: '100%',
+  height: '100%',
+
+  color: vars.textColor,
+  backgroundColor: vars.backgroundColor,
+});
+
+export const buttonListStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  alignSelf: 'flex-end',
+  gap: '1rem',
+});
+
+export const tagListStyle = style({
+  display: 'flex',
+  gap: '0.25rem',
+});

--- a/src/Page/QuestionDetailPage/Multiple/index.tsx
+++ b/src/Page/QuestionDetailPage/Multiple/index.tsx
@@ -1,4 +1,4 @@
-import Header from '../../Template/Header';
+import Header from '../../../Template/Header';
 import Split from 'react-split';
 import {
   themeLightClass,
@@ -13,36 +13,48 @@ import {
   problemDescContentStyle,
   buttonListStyle,
   themeDarkClass,
-  answerInputContentStyle,
+  choiceListStyle,
+  choiceWrapperStyle,
+  choiceCheckboxStyle,
   tagListStyle,
 } from './style.css';
-import './gutter.css';
+import '../gutter.css';
 import { Link, useParams } from 'react-router-dom';
-import Tag from '../../Component/Box/TagBox';
-import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../types/button';
-import TextButton from '../../Component/Button/TextButton';
-import { ReactComponent as SunIcon } from '../../assets/icons/sun.svg';
-import { ReactComponent as MoonIcon } from '../../assets/icons/moon.svg';
-import { useAuthStore } from '../../hooks/useStore';
+import Tag from '../../../Component/Box/TagBox';
+import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../../types/button';
+import TextButton from '../../../Component/Button/TextButton';
+import { ReactComponent as SunIcon } from '../../../assets/icons/sun.svg';
+import { ReactComponent as MoonIcon } from '../../../assets/icons/moon.svg';
+import { useAuthStore } from '../../../hooks/useStore';
 import { useEffect, useState } from 'react';
-import baseFontStyle from '../../styles/font.css';
-import { problemApiWrapper } from '../../api/wrapper/problem/problemApiWrapper';
-import { URL, URLWithParam } from '../../constants/url';
-import { IProblemDetailResponseData } from '../../types/api/problem';
+import baseFontStyle from '../../../styles/font.css';
+import { problemApiWrapper } from '../../../api/wrapper/problem/problemApiWrapper';
+import { URL, URLWithParam } from '../../../constants/url';
+import { IProblemDetailResponseData } from '../../../types/api/problem';
 
-function QuestionDetailPage() {
+const choices = [
+  { id: 0, content: '선택지1' },
+  { id: 1, content: '선택지2' },
+  { id: 2, content: '선택지3' },
+];
+
+export function MultipleQuestionDetailPage() {
   const { id } = useParams();
   const { isLogin } = useAuthStore();
   const [data, setData] = useState<IProblemDetailResponseData>();
 
-  const [isDark, setIsDark] = useState(false);
+  const [isDark, setIsDark] = useState(true);
 
   function toggleDarkMode() {
     setIsDark((prev) => !prev);
   }
 
   function handleSubmit() {
-    return;
+    const choices: boolean[] = [];
+    const checkboxes = document.querySelectorAll(
+      'input[type="checkbox"]',
+    ) as NodeListOf<HTMLInputElement>;
+    checkboxes.forEach((e) => choices.push(e.checked));
   }
 
   useEffect(() => {
@@ -96,20 +108,31 @@ function QuestionDetailPage() {
                 </div>
                 <div className={contentWrapperStyle}>
                   <label htmlFor='answer' className={contentTitleStyle}>
-                    답안 작성
+                    답안 선택
                   </label>
-                  <textarea
-                    id='answer'
-                    placeholder='답변을 입력해주세요'
-                    className={answerInputContentStyle}
-                  ></textarea>
+                  <div className={choiceListStyle}>
+                    {choices.map((choice) => (
+                      <label
+                        htmlFor={choice.id.toString()}
+                        className={choiceWrapperStyle}
+                        key={choice.id}
+                      >
+                        <input
+                          type='checkbox'
+                          id={choice.id.toString()}
+                          className={choiceCheckboxStyle}
+                        />
+                        {choice.content}
+                      </label>
+                    ))}
+                  </div>
                 </div>
               </Split>
             </div>
 
             <div className={buttonListStyle}>
               {isLogin ? (
-                <Link to={URLWithParam.LONG_PROBLEM_RESULT(id!)}>
+                <Link to={URLWithParam.MULTIPLE_PROBLEM_RESULT(id!)}>
                   <TextButton
                     type={BUTTON_TYPE.SUBMIT}
                     theme={BUTTON_THEME.PRIMARY}
@@ -146,4 +169,3 @@ function QuestionDetailPage() {
     </div>
   );
 }
-export default QuestionDetailPage;

--- a/src/Page/QuestionDetailPage/Multiple/style.css.ts
+++ b/src/Page/QuestionDetailPage/Multiple/style.css.ts
@@ -1,0 +1,183 @@
+import { createThemeContract, createTheme, style, keyframes } from '@vanilla-extract/css';
+import { COLOR } from '../../../constants/color';
+import baseFontStyle from '../../../styles/font.css';
+
+export const vars = createThemeContract({
+  backgroundColor: null,
+  contentBackgroundColor: null,
+  textColor: null,
+});
+
+export const themeLightClass = createTheme(vars, {
+  backgroundColor: COLOR.WHITE,
+  contentBackgroundColor: COLOR.OFFWHITE,
+  textColor: COLOR.TITLEACTIVE,
+});
+
+export const themeDarkClass = createTheme(vars, {
+  backgroundColor: COLOR.TITLEACTIVE,
+  contentBackgroundColor: COLOR.DARKGRAY,
+  textColor: COLOR.WHITE,
+});
+
+const spread = keyframes({
+  '0%': { backgroundColor: 'inherit' },
+  '100%': { backgroundColor: vars.backgroundColor },
+});
+
+export const pageStyle = style({
+  boxSizing: 'border-box',
+
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-start',
+  alignItems: 'stretch',
+  gap: '1.5rem',
+
+  width: '100%',
+
+  color: vars.textColor,
+  backgroundColor: vars.backgroundColor,
+
+  transition: 'background-color 0.2s',
+  animation: spread,
+  padding: '3rem',
+});
+
+export const topStyle = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+
+  width: '100%',
+});
+
+export const descStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  justifyContent: 'center',
+});
+
+export const titleTagStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.5rem',
+});
+
+export const questionContentStyle = style({
+  display: 'flex',
+  height: '60vh',
+  background: vars.contentBackgroundColor,
+  padding: ' 0 1.5rem',
+  borderRadius: '10px',
+});
+
+export const splitStyle = style({
+  display: 'flex',
+  width: '100%',
+});
+
+export const contentWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  gap: '2rem',
+
+  padding: '1.5rem 0',
+});
+
+export const contentTitleStyle = style([
+  baseFontStyle.xlarge,
+  {
+    color: vars.textColor,
+  },
+]);
+
+export const problemDescContentStyle = style([
+  baseFontStyle.small,
+  {
+    overflowY: 'scroll',
+    color: vars.textColor,
+  },
+]);
+
+export const questionDescStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
+  gap: '2.5rem',
+});
+
+export const answerInputStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const answerInputContentStyle = style({
+  display: 'flex',
+
+  width: '100%',
+  height: '100%',
+
+  color: vars.textColor,
+  backgroundColor: vars.backgroundColor,
+});
+
+export const buttonListStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  alignSelf: 'flex-end',
+  gap: '1rem',
+});
+
+export const tagListStyle = style({
+  display: 'flex',
+  gap: '0.25rem',
+});
+
+export const choiceListStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+
+  width: '100%',
+});
+
+export const choiceWrapperStyle = style([
+  baseFontStyle.medium,
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    width: '100%',
+    padding: '1.125rem',
+    borderRadius: '10px',
+    backgroundColor: vars.backgroundColor,
+    cursor: 'pointer',
+
+    ':hover': {
+      border: '1px solid',
+      borderColor: COLOR.GRAY,
+    },
+  },
+]);
+
+export const choiceCheckboxStyle = style({
+  flex: '0 0 auto',
+  margin: '0px 0.875rem 0px 0px',
+
+  width: '1.25rem',
+  height: '1.25rem',
+
+  border: '2px',
+  borderColor: COLOR.DARKGRAY,
+  borderRadius: '10px',
+
+  background: 'inherit',
+});

--- a/src/Page/QuestionDetailPage/Short/index.tsx
+++ b/src/Page/QuestionDetailPage/Short/index.tsx
@@ -1,0 +1,148 @@
+import Header from '../../../Template/Header';
+import Split from 'react-split';
+import {
+  themeLightClass,
+  pageStyle,
+  topStyle,
+  descStyle,
+  titleTagStyle,
+  questionContentStyle,
+  splitStyle,
+  contentWrapperStyle,
+  contentTitleStyle,
+  problemDescContentStyle,
+  buttonListStyle,
+  themeDarkClass,
+  answerInputContentStyle,
+  tagListStyle,
+} from './style.css';
+import '../gutter.css';
+import { Link, useParams } from 'react-router-dom';
+import Tag from '../../../Component/Box/TagBox';
+import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../../types/button';
+import TextButton from '../../../Component/Button/TextButton';
+import { ReactComponent as SunIcon } from '../../../assets/icons/sun.svg';
+import { ReactComponent as MoonIcon } from '../../../assets/icons/moon.svg';
+import { useAuthStore } from '../../../hooks/useStore';
+import { useEffect, useState } from 'react';
+import baseFontStyle from '../../../styles/font.css';
+import { problemApiWrapper } from '../../../api/wrapper/problem/problemApiWrapper';
+import { URL, URLWithParam } from '../../../constants/url';
+import { IProblemDetailResponseData } from '../../../types/api/problem';
+
+export function ShortQuestionDetailPage() {
+  const { id } = useParams();
+  const { isLogin } = useAuthStore();
+  const [data, setData] = useState<IProblemDetailResponseData>();
+
+  const [isDark, setIsDark] = useState(true);
+
+  function toggleDarkMode() {
+    setIsDark((prev) => !prev);
+  }
+
+  function handleSubmit() {
+    return;
+  }
+
+  useEffect(() => {
+    if (!id) return;
+    problemApiWrapper.problemDetail(id).then((res) => {
+      setData(res.data);
+    });
+  }, []);
+
+  return (
+    <div>
+      {data ? (
+        <>
+          <Header />
+          <main className={`${isDark ? themeDarkClass : themeLightClass} ${pageStyle}`}>
+            <div className={topStyle}>
+              <div className={descStyle}>
+                <div className={titleTagStyle}>
+                  <h1 className={baseFontStyle.title}>{data?.title}</h1>
+                  <ul className={tagListStyle}>
+                    {data?.tags.map((tagId) => (
+                      <Tag tagId={tagId} key={tagId} />
+                    ))}
+                  </ul>
+                </div>
+                <div className={baseFontStyle.medium}>
+                  {`제출 : ${data?.totalSolved ?? 0}, 평균 점수 : ${
+                    data?.avgScore ?? 0
+                  }점, 최고점 : ${data?.topScore ?? 0}점 , 최저점 : ${data?.bottomScore ?? 0}점`}
+                </div>
+              </div>
+
+              <button onClick={toggleDarkMode}>{isDark ? <MoonIcon /> : <SunIcon />}</button>
+            </div>
+            <div className={questionContentStyle}>
+              <Split
+                sizes={[25, 75]}
+                minSize={100}
+                expandToMin={false}
+                gutterSize={10}
+                gutterAlign='center'
+                snapOffset={30}
+                dragInterval={1}
+                direction='horizontal'
+                cursor='col-resize'
+                className={splitStyle}
+              >
+                <div className={contentWrapperStyle}>
+                  <div className={contentTitleStyle}>문제 설명</div>
+                  <div className={problemDescContentStyle}>{data?.description}</div>
+                </div>
+                <div className={contentWrapperStyle}>
+                  <label htmlFor='answer' className={contentTitleStyle}>
+                    답안 작성
+                  </label>
+                  <input
+                    id='answer'
+                    placeholder='답변을 입력해주세요'
+                    className={answerInputContentStyle}
+                  ></input>
+                </div>
+              </Split>
+            </div>
+
+            <div className={buttonListStyle}>
+              {isLogin ? (
+                <Link to={URLWithParam.SHORT_PROBLEM_RESULT(id!)}>
+                  <TextButton
+                    type={BUTTON_TYPE.SUBMIT}
+                    theme={BUTTON_THEME.PRIMARY}
+                    size={BUTTON_SIZE.MEDIUM}
+                    onClick={handleSubmit}
+                  >
+                    제출하기
+                  </TextButton>
+                </Link>
+              ) : (
+                <TextButton
+                  type={BUTTON_TYPE.SUBMIT}
+                  theme={BUTTON_THEME.PRIMARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                >
+                  로그인
+                </TextButton>
+              )}
+              <Link to={URL.PROBLEM_LIST}>
+                <TextButton
+                  type={BUTTON_TYPE.BUTTON}
+                  theme={BUTTON_THEME.SECONDARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                >
+                  돌아가기
+                </TextButton>
+              </Link>
+            </div>
+          </main>
+        </>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+}

--- a/src/Page/QuestionDetailPage/Short/style.css.ts
+++ b/src/Page/QuestionDetailPage/Short/style.css.ts
@@ -1,6 +1,6 @@
 import { createThemeContract, createTheme, style, keyframes } from '@vanilla-extract/css';
-import { COLOR } from '../../constants/color';
-import baseFontStyle from '../../styles/font.css';
+import { COLOR } from '../../../constants/color';
+import baseFontStyle from '../../../styles/font.css';
 
 export const vars = createThemeContract({
   backgroundColor: null,
@@ -122,7 +122,8 @@ export const answerInputContentStyle = style({
   display: 'flex',
 
   width: '100%',
-  height: '100%',
+
+  padding: '1rem',
 
   color: vars.textColor,
   backgroundColor: vars.backgroundColor,

--- a/src/Page/index.ts
+++ b/src/Page/index.ts
@@ -1,6 +1,8 @@
 import MainPage from './MainPage';
-import QuestionDetailPage from './QuestionDetailPage';
 import QuestionListPage from './QuestionListPage';
+import { LongQuestionDetailPage } from './QuestionDetailPage/Long';
+import { ShortQuestionDetailPage } from './QuestionDetailPage/Short';
+import { MultipleQuestionDetailPage } from './QuestionDetailPage/Multiple';
 import ResultPage from './ResultPage';
 import NicknamePage from './NicknamePage';
 import JoinPage from './JoinPage';
@@ -9,7 +11,9 @@ import CallbackPage from './CallbackPage';
 export {
   MainPage,
   QuestionListPage,
-  QuestionDetailPage,
+  LongQuestionDetailPage,
+  ShortQuestionDetailPage,
+  MultipleQuestionDetailPage,
   ResultPage,
   CallbackPage,
   NicknamePage,

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,11 +3,13 @@ import { URL } from './constants/url';
 import {
   MainPage,
   QuestionListPage,
-  QuestionDetailPage,
+  LongQuestionDetailPage,
   ResultPage,
   NicknamePage,
   JoinPage,
   CallbackPage,
+  ShortQuestionDetailPage,
+  MultipleQuestionDetailPage,
 } from './Page';
 
 function Router() {
@@ -16,8 +18,12 @@ function Router() {
       <Routes>
         <Route path={URL.MAIN} element={<MainPage />} />
         <Route path={URL.PROBLEM_LIST} element={<QuestionListPage />} />
-        <Route path={URL.LONG_PROBLEM_DETAIL} element={<QuestionDetailPage />} />
+        <Route path={URL.LONG_PROBLEM_DETAIL} element={<LongQuestionDetailPage />} />
         <Route path={URL.LONG_PROBLEM_RESULT} element={<ResultPage />} />
+        <Route path={URL.SHORT_PROBLEM_DETAIL} element={<ShortQuestionDetailPage />} />
+        <Route path={URL.SHORT_PROBLEM_RESULT} element={<ResultPage />} />
+        <Route path={URL.MULTIPLE_PROBLEM_DETAIL} element={<MultipleQuestionDetailPage />} />
+        <Route path={URL.MULTIPLE__PROBLEM_RESULT} element={<ResultPage />} />
         <Route path={URL.JOIN} element={<JoinPage />} />
         <Route path={URL.NICKNAME} element={<NicknamePage />} />
         <Route path={URL.OAUTH_CALLBACK} element={<CallbackPage />} />

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -7,6 +7,8 @@ const URL = {
   LONG_PROBLEM_RESULT: '/problem/long/result/:id',
   SHORT_PROBLEM_DETAIL: '/problem/short/:id',
   SHORT_PROBLEM_RESULT: '/problem/short/result/:id',
+  MULTIPLE_PROBLEM_DETAIL: '/problem/multiple/:id',
+  MULTIPLE__PROBLEM_RESULT: '/problem/multiple/result/:id',
   OAUTH_CALLBACK: '/oauth/redirect',
 };
 
@@ -15,6 +17,8 @@ const URLWithParam = {
   LONG_PROBLEM_RESULT: (id: string) => `/problem/long/result/${id}`,
   SHORT_PROBLEM_DETAIL: (id: string) => `/problem/short/${id}`,
   SHORT_PROBLEM_RESULT: (id: string) => `/problem/short/result/${id}`,
+  MULTIPLE_PROBLEM_DETAIL: (id: string) => `/problem/multiple/${id}`,
+  MULTIPLE_PROBLEM_RESULT: (id: string) => `/problem/multiple/result/${id}`,
 };
 
 export { URL, URLWithParam };


### PR DESCRIPTION
### Issue Number

close: MSTR-165, MSTR-166

### 작업 내역

> 구현 내용 및 작업 했던 내역

<img width="1072" alt="스크린샷 2022-08-14 오후 5 10 27" src="https://user-images.githubusercontent.com/63906230/184528454-fa0036f1-ebf4-4418-a004-8aa5eab780b4.png">
<img width="1072" alt="스크린샷 2022-08-14 오후 5 10 17" src="https://user-images.githubusercontent.com/63906230/184528458-56037730-1302-468d-a265-a1ffba97b542.png">

- [x] 객관식 페이지
- [x] 단답형 페이지

### 변경사항
- 문제 풀이 페이지 default를 다크모드로 변경했습니다.

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- long, short, multiple에 공통요소가 많은 상태이지만 채점 API를 보고 어디까지 공통 template으로 뺄지 고민해볼 예정입니다.
- 문제 리스트 페이지에서 상세 페이지로 넘어갈때 해당 문제가 어떤 type을 가졌는지 알 수 없어서 merge 되더라도 url에 직접 `/problem/multiple/8`,`/problem/short/8` 이런식으로 작성하여 들어가야 합니다.
