### PR TITLE
MSTR-185 : 필터 상태관리

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint"],
+  "plugins": ["react", "@typescript-eslint", "unused-imports"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
@@ -31,6 +31,12 @@
     "prefer-arrow-callback": "error",
     "no-trailing-spaces": "error",
     "quotes": ["warn", "single", { "avoidEscape": true }],
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
+    ],
     "no-restricted-properties": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "prefer-arrow-callback": "error",
     "no-trailing-spaces": "error",
     "quotes": ["warn", "single", { "avoidEscape": true }],
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": "warning",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "prefer-arrow-callback": "error",
     "no-trailing-spaces": "error",
     "quotes": ["warn", "single", { "avoidEscape": true }],
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,7 @@
     "prefer-arrow-callback": "error",
     "no-trailing-spaces": "error",
     "quotes": ["warn", "single", { "avoidEscape": true }],
-    "@typescript-eslint/no-unused-vars": "warning",
+    "@typescript-eslint/no-unused-vars": "warn",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "prettier": "^2.7.1",
         "typescript": "^4.6.3",
         "vite": "^2.9.9"
@@ -2712,6 +2713,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -6851,6 +6882,21 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^2.7.1",
     "typescript": "^4.6.3",
     "vite": "^2.9.9"

--- a/src/Component/Button/TextButton/index.tsx
+++ b/src/Component/Button/TextButton/index.tsx
@@ -2,12 +2,12 @@ import { IButtonDetail } from '../../../types/button';
 import { buttonThemeClass } from '../theme.css';
 import { textButtonSizeStyle, textButtonThemeStyle } from './style.css';
 
-function TextButton({ type, theme, size, onClick, children }: IButtonDetail) {
+function TextButton({ type, theme, size, onClick, children, className }: IButtonDetail) {
   return (
     <button
       type={type}
       onClick={onClick}
-      className={`${buttonThemeClass} ${textButtonThemeStyle[theme]} ${textButtonSizeStyle[size]}`}
+      className={`${buttonThemeClass} ${textButtonThemeStyle[theme]} ${textButtonSizeStyle[size]} ${className}`}
     >
       {children}
     </button>

--- a/src/Component/Button/TextButton/style.css.ts
+++ b/src/Component/Button/TextButton/style.css.ts
@@ -31,6 +31,7 @@ export const textButtonThemeStyle = styleVariants({
 });
 
 export const textButtonSizeStyle = styleVariants({
+  small: [{ width: vars.size.small.width, height: vars.size.small.height }],
   medium: [{ width: vars.size.medium.width, height: vars.size.medium.height }],
   large: [{ width: vars.size.large.width, height: vars.size.large.height }],
 });

--- a/src/Component/Button/TransparentButton/index.tsx
+++ b/src/Component/Button/TransparentButton/index.tsx
@@ -1,9 +1,9 @@
 import { IButton } from '../../../types/button';
 import { transparentButtonStyle } from './style.css';
 
-function TransparentButton({ type, children, onClick }: IButton) {
+function TransparentButton({ type, children, className, onClick }: IButton) {
   return (
-    <button type={type} className={transparentButtonStyle} onClick={onClick}>
+    <button type={type} className={`${transparentButtonStyle} ${className}`} onClick={onClick}>
       {children}
     </button>
   );

--- a/src/Component/Button/theme.css.ts
+++ b/src/Component/Button/theme.css.ts
@@ -13,6 +13,10 @@ export const [buttonThemeClass, vars] = createTheme({
     secondary: { back: COLOR.GRAY, text: COLOR.TITLEACTIVE },
   },
   size: {
+    small: {
+      width: '3.5rem',
+      height: '2rem',
+    },
     medium: {
       width: '9.25rem',
       height: '4.125rem',

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { INPUT_TYPE } from '../../../constants/input';
 import { TAG_MAP_BY_ID } from '../../../constants/tag';
 import { IDropdownElement } from '../../../types/util';
+import { resetSearchProblemInput } from '../../../utils/resetSearchProblemInputs';
 
 interface IDropdownComponentProps extends IDropdownElement {
   handleCheckedTags: (tagId: string, isChecked: boolean) => void;
@@ -13,6 +14,7 @@ interface IDropdownComponentProps extends IDropdownElement {
 function DropdownElement({ id, handleCheckedTags }: IDropdownComponentProps) {
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
     handleCheckedTags(target.id, target.checked);
+    resetSearchProblemInput();
   }
 
   return (

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { INPUT_TYPE } from '../../../constants/input';
 import { TAG_MAP_BY_ID } from '../../../constants/tag';
 import { IDropdownElement } from '../../../types/util';

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { INPUT_TYPE } from '../../../constants/input';
 import { TAG_MAP_BY_ID } from '../../../constants/tag';
 import { IDropdownElement } from '../../../types/util';
@@ -11,10 +11,7 @@ interface IDropdownComponentProps extends IDropdownElement {
 }
 
 function DropdownElement({ id, handleCheckedTags }: IDropdownComponentProps) {
-  const [isChecked, setIsChecked] = useState(false);
-
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
-    setIsChecked(!isChecked);
     handleCheckedTags(target.id, target.checked);
   }
 

--- a/src/Page/QuestionListPage/index.tsx
+++ b/src/Page/QuestionListPage/index.tsx
@@ -14,6 +14,8 @@ import {
   filterStyle,
   filterTitleStyle,
   questionListStyle,
+  resetButtonStyle,
+  filterTitleWrapperStyle,
 } from './style.css';
 import { PageTemplate } from '../../Template';
 import { useEffect, useState } from 'react';
@@ -21,10 +23,13 @@ import { problemApiWrapper } from '../../api/wrapper/problem/problemApiWrapper';
 import { IProblemListResponseData } from '../../types/api/problem';
 import { getFilterParams } from '../../utils/getFilterParams';
 import { getTagById } from '../../utils/getTagbyId';
+import { TextButton } from '../../Component/Button';
+import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../types/button';
+import { resetSearchProblemInput, resetCheckboxes } from '../../utils/resetSearchProblemInputs';
 
 function QuestionListPage() {
   const [problemList, setProblemList] = useState<IProblemListResponseData[]>([]);
-  const { checkedTags, handleCheckedTags } = useCheckedTagsStore();
+  const { checkedTags, handleCheckedTags, resetCheckedTags } = useCheckedTagsStore();
   const [page, setPage] = useState(0);
   const { isLogin } = useAuthStore();
 
@@ -34,6 +39,7 @@ function QuestionListPage() {
     problemApiWrapper.problemList(params).then((res) => {
       setProblemList(res.data);
     });
+    resetCheckedTags(resetCheckboxes);
   }
 
   useEffect(() => {
@@ -51,7 +57,21 @@ function QuestionListPage() {
           <aside className={asideStyle}>
             <SearchInputBox handleSearchInput={handleSearchInput} />
             <div className={filterStyle}>
-              <div className={filterTitleStyle}>필터</div>
+              <div className={filterTitleWrapperStyle}>
+                <div className={filterTitleStyle}>문제 검색</div>
+                <TextButton
+                  type={BUTTON_TYPE.BUTTON}
+                  className={resetButtonStyle}
+                  onClick={() => {
+                    resetCheckedTags(resetCheckboxes);
+                    resetSearchProblemInput();
+                  }}
+                  theme={BUTTON_THEME.SECONDARY}
+                  size={BUTTON_SIZE.SMALL}
+                >
+                  초기화
+                </TextButton>
+              </div>
               <div className={dropdownListStyle}>
                 {isLogin
                   ? TAGLIST.map((tagtype) => (

--- a/src/Page/QuestionListPage/index.tsx
+++ b/src/Page/QuestionListPage/index.tsx
@@ -72,10 +72,12 @@ function QuestionListPage() {
                     ))}
               </div>
               <ul className={checkedTagListStyle}>
-                {[...checkedTags].map((tag) => {
-                  const { name, color } = getTagById(tag.id);
-                  return <TagBox key={tag.id} name={name} color={color} />;
-                })}
+                {[...checkedTags]
+                  .filter((tag) => tag.isChecked)
+                  .map((tag) => {
+                    const { name, color } = getTagById(tag.id);
+                    return <TagBox key={tag.id} name={name} color={color} />;
+                  })}
               </ul>
             </div>
           </aside>

--- a/src/Page/QuestionListPage/style.css.ts
+++ b/src/Page/QuestionListPage/style.css.ts
@@ -41,6 +41,15 @@ export const filterStyle = style({
   padding: '1.25rem',
 });
 
+export const filterTitleWrapperStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+
+  padding: '0 0.5rem',
+});
+
 export const filterTitleStyle = style([
   baseFontStyle.medium,
   {
@@ -92,3 +101,11 @@ export const questionListStyle = style({
     },
   },
 });
+
+export const resetButtonStyle = style([
+  baseFontStyle.xsmall,
+  {
+    padding: 0,
+    alignSelf: 'end',
+  },
+]);

--- a/src/api/wrapper/problem/problemApiWrapper.ts
+++ b/src/api/wrapper/problem/problemApiWrapper.ts
@@ -1,10 +1,21 @@
+import { getUserInfo } from './../../../utils/userInfo';
 import apiClient from '../../apiClient';
 import { API_URL, API_URL_WITH_PARAMS } from '../../../constants/apiUrl';
 import { IProblemRequestParam } from '../../../types/api/problem';
+import { BEARER_TOKEN } from '../../../constants/api';
+import { AxiosRequestConfig } from 'axios';
 
 export const problemApiWrapper = {
   problemList: (params: IProblemRequestParam) => {
-    return apiClient.get(API_URL.PROBLEM_LIST, { params: params });
+    const config: AxiosRequestConfig<any> = {
+      params: params,
+    };
+    if (params.isSolved) {
+      const userInfo = getUserInfo();
+      if (!userInfo) throw new Error('userinfo not found');
+      config.headers = { Authorization: BEARER_TOKEN(userInfo.accessToken) };
+    }
+    return apiClient.get(API_URL.PROBLEM_LIST, config);
   },
   problemDetail: (problem_id: string) => {
     return apiClient.get(API_URL_WITH_PARAMS.PROBLEM_DETAIL(problem_id));

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -4,6 +4,7 @@ import { ITagState } from '../types/tag';
 interface ICheckedTags {
   checkedTags: ITagState[];
   handleCheckedTags: (id: string, isChecked: boolean) => void;
+  resetCheckedTags: (resetCheckboxes: () => void) => void;
 }
 
 interface IAuth {
@@ -25,13 +26,18 @@ interface IUserInfoStore {
 
 const useCheckedTagsStore = create<ICheckedTags>((set) => ({
   checkedTags: [],
-  handleCheckedTags: (id: string, isChecked: boolean) =>
+  handleCheckedTags: (id: string, isChecked: boolean) => {
     set((state) => ({
       ...state,
       checkedTags: state.checkedTags.map((tag) => tag.id).includes(id)
         ? state.checkedTags.map((tag) => (tag.id === id ? { id, isChecked } : tag))
         : [...state.checkedTags, { id, isChecked }],
-    })),
+    }));
+  },
+  resetCheckedTags: (resetCheckboxes: () => void) => {
+    resetCheckboxes();
+    return set({ checkedTags: [] });
+  },
 }));
 
 const useAuthStore = create<IAuth>((set) => ({

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -2,7 +2,7 @@ import create from 'zustand';
 import { ITagState } from '../types/tag';
 
 interface ICheckedTags {
-  checkedTags: Set<ITagState>;
+  checkedTags: ITagState[];
   handleCheckedTags: (id: string, isChecked: boolean) => void;
 }
 
@@ -24,13 +24,13 @@ interface IUserInfoStore {
 }
 
 const useCheckedTagsStore = create<ICheckedTags>((set) => ({
-  checkedTags: new Set<ITagState>(),
+  checkedTags: [],
   handleCheckedTags: (id: string, isChecked: boolean) =>
-    set((state: ICheckedTags) => ({
-      checkedTags: new Set([
-        ...[...state.checkedTags].filter((tag) => tag.id !== id),
-        { id: id, isChecked: isChecked },
-      ]),
+    set((state) => ({
+      ...state,
+      checkedTags: state.checkedTags.map((tag) => tag.id).includes(id)
+        ? state.checkedTags.map((tag) => (tag.id === id ? { id, isChecked } : tag))
+        : [...state.checkedTags, { id, isChecked }],
     })),
 }));
 

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -6,6 +6,7 @@ export interface IButton {
   theme?: TButtonTheme;
   size?: TButtonSize;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  className?: string;
 }
 
 export interface IButtonDetail extends IButton {
@@ -21,6 +22,6 @@ export const BUTTON_THEME = { PRIMARY: 'primary', SECONDARY: 'secondary' } as co
 
 export type TButtonTheme = typeof BUTTON_THEME[keyof typeof BUTTON_THEME];
 
-export const BUTTON_SIZE = { LARGE: 'large', MEDIUM: 'medium' } as const;
+export const BUTTON_SIZE = { LARGE: 'large', MEDIUM: 'medium', SMALL: 'small' } as const;
 
 export type TButtonSize = typeof BUTTON_SIZE[keyof typeof BUTTON_SIZE];

--- a/src/utils/getFilterParams.ts
+++ b/src/utils/getFilterParams.ts
@@ -12,27 +12,31 @@ const isGradableMap: Record<string, boolean> = {
   ungradable: false,
 };
 
-export const getFilterParams = (checkedTags: Set<ITagState>) => {
-  const checkedTagsArray = Array.from(checkedTags);
+const isTagSelected = (checkedTags: ITagState[], array: string[]) => {
+  return checkedTags.filter((e) => array.includes(e.id) && e.isChecked).map((e) => e.id);
+};
 
+export const getFilterParams = (checkedTags: ITagState[]) => {
   const categoryTagIds = TAGLIST.find((e) => e.name === '카테고리')?.elements.map((e) => e.id);
-  const solveTagIds = TAGLIST.find((e) => e.name === '풀이 여부')?.elements.map((e) => e.id);
   const typeIds = TAGLIST.find((e) => e.name === '문제 유형')?.elements.map((e) => e.id);
+  const solveTagIds = TAGLIST.find((e) => e.name === '풀이 여부')?.elements.map((e) => e.id);
   const gradableIds = TAGLIST.find((e) => e.name === '채점 가능 여부')?.elements.map((e) => e.id);
 
-  const isSolved = checkedTagsArray.filter(({ id }) => solveTagIds?.includes(id));
-  const isSolvedParam = isSolved.length === 1 ? isSolvedMap[isSolved[0].id] : null;
+  if (!categoryTagIds || !solveTagIds || !typeIds || !gradableIds) return;
+
   const query = (document.getElementById('search-problem') as HTMLInputElement).value;
-  const tags = checkedTagsArray.filter(({ id }) => categoryTagIds?.includes(id)).map((e) => e.id);
-  const type = checkedTagsArray.filter(({ id }) => typeIds?.includes(id)).map((e) => e.id);
-  const isGradable = checkedTagsArray.filter(({ id }) => gradableIds?.includes(id));
-  const isGradableParam = isGradable.length === 1 ? isGradableMap[isGradable[0].id] : null;
+  const tags = isTagSelected(checkedTags, categoryTagIds);
+  const type = isTagSelected(checkedTags, typeIds);
+  const isSolved = isTagSelected(checkedTags, solveTagIds);
+  const isSolvedParam = isSolved.length === 1 ? isSolvedMap[isSolved[0]] : null;
+  const isGradable = isTagSelected(checkedTags, gradableIds);
+  const isGradableParam = isGradable.length === 1 ? isGradableMap[isGradable[0]] : null;
 
   const params: IProblemRequestParam = {
-    isSolved: isSolvedParam,
-    tags: tags.join(','),
     query: query,
+    tags: tags.join(','),
     type: type.join(','),
+    isSolved: isSolvedParam,
     isGradable: isGradableParam,
   };
 

--- a/src/utils/resetSearchProblemInputs.ts
+++ b/src/utils/resetSearchProblemInputs.ts
@@ -1,0 +1,11 @@
+export const resetSearchProblemInput = () => {
+  const searchProblemInput = document.getElementById('search-problem') as HTMLInputElement;
+  searchProblemInput.value = '';
+};
+
+export const resetCheckboxes = () => {
+  const checkboxes = document.querySelectorAll(
+    'input[type="checkbox"]',
+  ) as NodeListOf<HTMLInputElement>;
+  checkboxes.forEach((checkbox) => (checkbox.checked = false));
+};

--- a/src/utils/userInfo.ts
+++ b/src/utils/userInfo.ts
@@ -10,9 +10,9 @@ export const setUserInfo = (userInfo: IUserInfo) => {
   }
 };
 
-export const getUserInfo = (): IUserInfo => {
+export const getUserInfo = (): IUserInfo | undefined => {
   const userInfoString = localStorage.getItem(USER_INFO);
-  if (!userInfoString) throw new Error('userinfo not found');
+  if (!userInfoString) return undefined;
 
   try {
     const userInfo = JSON.parse(userInfoString);


### PR DESCRIPTION
### 작업 내역

> 구현 내용 및 작업 했던 내역

<img width="206" alt="스크린샷 2022-08-17 오후 5 59 54" src="https://user-images.githubusercontent.com/63906230/185082186-1c4da317-977e-4448-89ae-8f25c19b7b48.png">


- [x] 필터 적용안되는 오류 수정
- [x] 필터 초기화 버튼 추가

### 변경사항

- 의존성 목록
    - [eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports) 추가

### 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 백준 필터링 방식을 참고해서 태그를 선택하면 검색창을 reset하고, 반대로 검색창을 이용해 검색하면 태그를 reset하도록 구현했는데 자연스럽게 느껴지는지, 다른 어떤 좋은 방법이 있을지 궁금합니다.
- checkbox(태그) reset시에 `utils > resetCheckboxes`와 `hooks > useStore > useCheckedTags`의 resetCheckedTags를 모두 호출해야해서 전자를 후자의 param으로 넘겨 하나로 묶었는데 checkbox 상태관리는 그대로 가져가면서 하나의 함수로 더 잘 묶을 수 있을지 고민입니다.
