### PR TITLE
MSTR-232: 정보수정 페이지

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
-VITE_MAJOR_OPEN_API_KEY=3da82601ae4e70ae3be5112a07bf35c5
 VITE_MAJOR_OPEN_API_URL=https://www.career.go.kr/cnet/openapi/getOpenApi.json

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_MAJOR_OPEN_API_KEY=3da82601ae4e70ae3be5112a07bf35c5
+VITE_MAJOR_OPEN_API_URL=https://www.career.go.kr/cnet/openapi/getOpenApi.json

--- a/src/Component/Box/InputBox/DefaultInputBox/index.tsx
+++ b/src/Component/Box/InputBox/DefaultInputBox/index.tsx
@@ -1,7 +1,7 @@
 import { IInputBox } from '../../../../types/box';
 import { defaultInputBoxStyle, inputBoxClass } from './style.css';
 
-function DefaultInputBox({ id, placeholder, type, children, name }: IInputBox) {
+function DefaultInputBox({ id, placeholder, type, children, name, onChange }: IInputBox) {
   return (
     <input
       id={id}
@@ -9,6 +9,7 @@ function DefaultInputBox({ id, placeholder, type, children, name }: IInputBox) {
       placeholder={placeholder}
       type={type}
       className={`${inputBoxClass} ${defaultInputBoxStyle}`}
+      onChange={onChange}
     >
       {children}
     </input>

--- a/src/Component/Box/InputBox/DefaultInputBox/style.css.ts
+++ b/src/Component/Box/InputBox/DefaultInputBox/style.css.ts
@@ -12,7 +12,7 @@ export const [inputBoxClass, inputVars] = createTheme({
 });
 
 export const defaultInputBoxStyle = style([
-  baseFontStyle.xlarge,
+  baseFontStyle.medium,
   {
     display: 'flex',
     alignItems: 'center',

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -20,9 +20,10 @@ import { IDropdownElement } from '../../../../types/util';
 interface ISearchDropdownInputBox {
   id: string;
   elements: IDropdownElement[];
+  searchWithAPI?: () => void;
 }
 
-export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox) {
+export function SearchDropdownInputBox({ id, elements, searchWithAPI }: ISearchDropdownInputBox) {
   const [isOpen, setIsOpen] = useState(false);
   const [checkedTags, setCheckedTags] = useState<ITagState[]>([]);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -49,6 +50,10 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
     setIsOpen(true);
   };
 
+  const focusOnInput = () => {
+    document.getElementById(id)?.focus();
+  };
+
   useEffect(listenOutsideClick(menuRef, setIsOpen), []);
 
   useEffect(() => {
@@ -56,7 +61,7 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
   }, [elements]);
 
   return (
-    <div ref={menuRef}>
+    <div ref={menuRef} onClick={focusOnInput}>
       <div className={searchInputBoxStyle} onClick={toggleDropdown}>
         <label htmlFor='id'></label>
         <input
@@ -64,7 +69,7 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
           className={inputTextBoxStyle}
           type={INPUT_TYPE.SEARCH}
           id={id}
-          onChange={search}
+          onChange={searchWithAPI ?? search}
         ></input>
         <IconButton type={BUTTON_TYPE.BUTTON} theme={BUTTON_THEME.PRIMARY}>
           <SearchIcon className={searchButtonStyle} />

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -51,6 +51,10 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
 
   useEffect(listenOutsideClick(menuRef, setIsOpen), []);
 
+  useEffect(() => {
+    setfilteredElements(elements);
+  }, [elements]);
+
   return (
     <div ref={menuRef}>
       <div className={searchInputBoxStyle} onClick={toggleDropdown}>

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -54,7 +54,7 @@ export function SearchDropdownInputBox({ id, elements, searchWithAPI }: ISearchD
     document.getElementById(id)?.focus();
   };
 
-  useEffect(listenOutsideClick(menuRef, setIsOpen), []);
+  useEffect(() => listenOutsideClick(menuRef, setIsOpen), []);
 
   useEffect(() => {
     setfilteredElements(elements);

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -10,7 +10,7 @@ import {
   dropDownListStyle,
   checkedTagListStyle,
 } from './style.css';
-import { useEffect, useRef, useState, MouseEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DropdownElement from '../../../Utils/Dropdown/DropdownElement';
 import { ITagState } from '../../../../types/tag';
 import TagBox from '../../TagBox';

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -10,21 +10,23 @@ import {
   dropDownListStyle,
   checkedTagListStyle,
 } from './style.css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, MouseEvent } from 'react';
 import DropdownElement from '../../../Utils/Dropdown/DropdownElement';
 import { ITagState } from '../../../../types/tag';
 import TagBox from '../../TagBox';
 import listenOutsideClick from '../../../../utils/listenOutsideClick';
+import { IDropdownElement } from '../../../../types/util';
 
 interface ISearchDropdownInputBox {
   id: string;
-  elements: any[];
+  elements: IDropdownElement[];
 }
 
 export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox) {
   const [isOpen, setIsOpen] = useState(false);
   const [checkedTags, setCheckedTags] = useState<ITagState[]>([]);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [filteredElements, setfilteredElements] = useState<IDropdownElement[]>(elements);
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -38,6 +40,15 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
     );
   };
 
+  const search = () => {
+    const inputValue = (document.getElementById(id) as HTMLInputElement).value;
+    const searchResult = elements.filter((e) =>
+      e.name.toLowerCase().includes(inputValue.toLowerCase()),
+    );
+    setfilteredElements(searchResult);
+    setIsOpen(true);
+  };
+
   useEffect(listenOutsideClick(menuRef, setIsOpen), []);
 
   return (
@@ -49,6 +60,7 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
           className={inputTextBoxStyle}
           type={INPUT_TYPE.SEARCH}
           id={id}
+          onChange={search}
         ></input>
         <IconButton type={BUTTON_TYPE.BUTTON} theme={BUTTON_THEME.PRIMARY}>
           <SearchIcon className={searchButtonStyle} />
@@ -56,7 +68,7 @@ export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox
       </div>
       <div className={dropDownContentStyle} style={{ visibility: isOpen ? 'visible' : 'hidden' }}>
         <ul className={dropDownListStyle}>
-          {elements.map((e) => (
+          {filteredElements.map((e) => (
             <DropdownElement
               id={e.id}
               name={e.name}

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/index.tsx
@@ -1,0 +1,78 @@
+import { ReactComponent as SearchIcon } from '../../../../assets/icons/search-icon.svg';
+import { INPUT_TYPE } from '../../../../constants/input';
+import { BUTTON_THEME, BUTTON_TYPE } from '../../../../types/button';
+import IconButton from '../../../Button/IconButton';
+import {
+  searchInputBoxStyle,
+  inputTextBoxStyle,
+  searchButtonStyle,
+  dropDownContentStyle,
+  dropDownListStyle,
+  checkedTagListStyle,
+} from './style.css';
+import { useEffect, useRef, useState } from 'react';
+import DropdownElement from '../../../Utils/Dropdown/DropdownElement';
+import { ITagState } from '../../../../types/tag';
+import TagBox from '../../TagBox';
+import listenOutsideClick from '../../../../utils/listenOutsideClick';
+
+interface ISearchDropdownInputBox {
+  id: string;
+  elements: any[];
+}
+
+export function SearchDropdownInputBox({ id, elements }: ISearchDropdownInputBox) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [checkedTags, setCheckedTags] = useState<ITagState[]>([]);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleCheckedTags = (id: string, name: string, isChecked: boolean) => {
+    setCheckedTags((prev) =>
+      prev.map((tag) => tag.id).includes(id)
+        ? prev.map((tag) => (tag.id === id ? { id, isChecked, name } : tag))
+        : [...prev, { id, isChecked, name }],
+    );
+  };
+
+  useEffect(listenOutsideClick(menuRef, setIsOpen), []);
+
+  return (
+    <div ref={menuRef}>
+      <div className={searchInputBoxStyle} onClick={toggleDropdown}>
+        <label htmlFor='id'></label>
+        <input
+          placeholder='검색어를 입력해주세요'
+          className={inputTextBoxStyle}
+          type={INPUT_TYPE.SEARCH}
+          id={id}
+        ></input>
+        <IconButton type={BUTTON_TYPE.BUTTON} theme={BUTTON_THEME.PRIMARY}>
+          <SearchIcon className={searchButtonStyle} />
+        </IconButton>
+      </div>
+      <div className={dropDownContentStyle} style={{ visibility: isOpen ? 'visible' : 'hidden' }}>
+        <ul className={dropDownListStyle}>
+          {elements.map((e) => (
+            <DropdownElement
+              id={e.id}
+              name={e.name}
+              handleCheckedTags={handleCheckedTags}
+              key={`${e.id}${e.name}`}
+            />
+          ))}
+        </ul>
+      </div>
+      <ul className={checkedTagListStyle}>
+        {[...checkedTags]
+          .filter((tag) => tag.isChecked)
+          .map((tag) => {
+            return <TagBox key={tag.id} name={tag.name} />;
+          })}
+      </ul>
+    </div>
+  );
+}

--- a/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/style.css.ts
+++ b/src/Component/Box/InputBox/SearchDropdownInputBox.tsx/style.css.ts
@@ -1,0 +1,61 @@
+import { style } from '@vanilla-extract/css';
+import { COLOR } from '../../../../constants/color';
+
+export const searchInputBoxStyle = style({
+  boxSizing: 'border-box',
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-around',
+  gap: '0.5rem',
+
+  width: '31.25rem',
+  height: '4.375rem',
+
+  border: '0.0625rem solid #d9d9d9',
+  borderRadius: '0.625rem',
+
+  padding: '0 1.25rem',
+
+  cursor: 'pointer',
+});
+
+export const inputTextBoxStyle = style({
+  width: '100%',
+  border: 'none',
+});
+
+export const searchButtonStyle = style({ width: '100%' });
+
+export const dropDownContentStyle = style({
+  position: 'absolute',
+  display: 'flex',
+  flexDirection: 'column',
+
+  width: '31.25rem',
+
+  padding: '1rem',
+
+  backgroundColor: COLOR.WHITE,
+  borderRadius: '20px',
+
+  filter: 'drop-shadow(0rem 0.25rem 0.25rem rgba(0, 0, 0, 0.25))',
+  zIndex: 1,
+});
+
+export const dropDownListStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  justifyContent: 'center',
+  gap: '1rem',
+});
+
+export const checkedTagListStyle = style({
+  display: 'flex',
+  alignItems: 'start',
+  justifyContent: 'start',
+  gap: '0.1rem',
+
+  padding: '0.5rem 0',
+});

--- a/src/Component/Box/TagBox/index.tsx
+++ b/src/Component/Box/TagBox/index.tsx
@@ -1,9 +1,9 @@
 import { ITagBox } from '../../../types/tag';
-import { tagBoxColorStyle, tagStyle } from './style.css';
+import { tagStyle } from './style.css';
 
 function TagBox({ name, color }: ITagBox) {
   return (
-    <li className={`${tagStyle} ${tagBoxColorStyle[color ?? 'color1']}`}>
+    <li className={tagStyle} style={{ backgroundColor: color }}>
       <div>{name}</div>
     </li>
   );

--- a/src/Component/Box/TagBox/index.tsx
+++ b/src/Component/Box/TagBox/index.tsx
@@ -3,7 +3,7 @@ import { tagBoxColorStyle, tagStyle } from './style.css';
 
 function TagBox({ name, color }: ITagBox) {
   return (
-    <li className={`${tagStyle} ${tagBoxColorStyle[color]}`}>
+    <li className={`${tagStyle} ${tagBoxColorStyle[color ?? 'color1']}`}>
       <div>{name}</div>
     </li>
   );

--- a/src/Component/Box/TagBox/style.css.ts
+++ b/src/Component/Box/TagBox/style.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import baseFontStyle from '../../../styles/font.css';
 
 export const tagStyle = style([
@@ -33,10 +33,3 @@ export const tagStyle = style([
     },
   },
 ]);
-
-export const tagBoxColorStyle = styleVariants({
-  color1: [{ backgroundColor: '#FFDED5' }],
-  color2: [{ backgroundColor: '#FCE38A' }],
-  color3: [{ backgroundColor: '#EAFFD0' }],
-  color4: [{ backgroundColor: '#95E1D3' }],
-});

--- a/src/Component/Button/TextButton/index.tsx
+++ b/src/Component/Button/TextButton/index.tsx
@@ -9,7 +9,7 @@ function TextButton({
   onClick,
   children,
   className,
-  isActivated,
+  isActivated = true,
 }: IButtonDetail) {
   return (
     <button

--- a/src/Component/Button/TextButton/index.tsx
+++ b/src/Component/Button/TextButton/index.tsx
@@ -2,12 +2,21 @@ import { IButtonDetail } from '../../../types/button';
 import { buttonThemeClass } from '../theme.css';
 import { textButtonSizeStyle, textButtonThemeStyle } from './style.css';
 
-function TextButton({ type, theme, size, onClick, children, className }: IButtonDetail) {
+function TextButton({
+  type,
+  theme,
+  size,
+  onClick,
+  children,
+  className,
+  isActivated,
+}: IButtonDetail) {
   return (
     <button
       type={type}
       onClick={onClick}
       className={`${buttonThemeClass} ${textButtonThemeStyle[theme]} ${textButtonSizeStyle[size]} ${className}`}
+      style={{ cursor: isActivated ? 'pointer' : 'not-allowed' }}
     >
       {children}
     </button>

--- a/src/Component/Message/WarningMessage/index.tsx
+++ b/src/Component/Message/WarningMessage/index.tsx
@@ -1,0 +1,14 @@
+import { warningMessageStyle } from './style.css';
+
+interface IWarningMessage {
+  children: string | React.ReactNode;
+  isShown: boolean;
+}
+
+export const WarningMessage = ({ children, isShown }: IWarningMessage) => {
+  return (
+    <div className={warningMessageStyle} style={{ display: isShown ? 'block' : 'none' }}>
+      {children}
+    </div>
+  );
+};

--- a/src/Component/Message/WarningMessage/style.css.ts
+++ b/src/Component/Message/WarningMessage/style.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+import { COLOR } from '../../../constants/color';
+
+export const warningMessageStyle = style({
+  color: COLOR.ERROR,
+});

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -4,16 +4,14 @@ import { css } from '@emotion/react';
 import { ChangeEvent } from 'react';
 import { INPUT_TYPE } from '../../../constants/input';
 import { IDropdownElement } from '../../../types/util';
-import { resetSearchProblemInput } from '../../../utils/resetSearchProblemInputs';
 
 interface IDropdownComponentProps extends IDropdownElement {
-  handleCheckedTags: (tagId: string, isChecked: boolean) => void;
+  handleCheckedTags: (tagId: string, name: string, isChecked: boolean) => void;
 }
 
 function DropdownElement({ id, name, handleCheckedTags }: IDropdownComponentProps) {
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
-    handleCheckedTags(target.id, target.checked);
-    resetSearchProblemInput();
+    handleCheckedTags(target.id, target.name, target.checked);
   }
 
   return (

--- a/src/Component/Utils/Dropdown/DropdownElement.tsx
+++ b/src/Component/Utils/Dropdown/DropdownElement.tsx
@@ -3,7 +3,6 @@
 import { css } from '@emotion/react';
 import { ChangeEvent } from 'react';
 import { INPUT_TYPE } from '../../../constants/input';
-import { TAG_MAP_BY_ID } from '../../../constants/tag';
 import { IDropdownElement } from '../../../types/util';
 import { resetSearchProblemInput } from '../../../utils/resetSearchProblemInputs';
 
@@ -11,7 +10,7 @@ interface IDropdownComponentProps extends IDropdownElement {
   handleCheckedTags: (tagId: string, isChecked: boolean) => void;
 }
 
-function DropdownElement({ id, handleCheckedTags }: IDropdownComponentProps) {
+function DropdownElement({ id, name, handleCheckedTags }: IDropdownComponentProps) {
   function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
     handleCheckedTags(target.id, target.checked);
     resetSearchProblemInput();
@@ -19,13 +18,8 @@ function DropdownElement({ id, handleCheckedTags }: IDropdownComponentProps) {
 
   return (
     <li css={dropdownContentElementStyle}>
-      <input
-        type={INPUT_TYPE.CHECKBOX}
-        name={TAG_MAP_BY_ID.get(id)?.name}
-        id={id}
-        onChange={checkHandler}
-      />
-      <label htmlFor={id}>{TAG_MAP_BY_ID.get(id)?.name}</label>
+      <input type={INPUT_TYPE.CHECKBOX} name={name} id={id} onChange={checkHandler} />
+      <label htmlFor={id}>{name}</label>
     </li>
   );
 }

--- a/src/Component/Utils/Dropdown/index.tsx
+++ b/src/Component/Utils/Dropdown/index.tsx
@@ -26,7 +26,7 @@ function Dropdown({ name, elements, handleCheckedTags }: IDropdownProps) {
     setIsOpen(!isOpen);
   }
 
-  useEffect(listenOutsideClick(menuRef, setIsOpen), []);
+  useEffect(() => listenOutsideClick(menuRef, setIsOpen), []);
 
   return (
     <div css={dropDownStyle} ref={menuRef}>

--- a/src/Component/Utils/Dropdown/index.tsx
+++ b/src/Component/Utils/Dropdown/index.tsx
@@ -5,9 +5,9 @@ import { useEffect, useRef, useState } from 'react';
 import { ReactComponent as DownIcon } from '../../../assets/icons/down-arrow-icon.svg';
 import { ReactComponent as UpIcon } from '../../../assets/icons/up-arrow-icon.svg';
 import DropdownElement from './DropdownElement';
-import listenOutsideClick from '../listenOutsideClick';
 import { BUTTON_TYPE } from '../../../types/button';
 import { IDropdownElement } from '../../../types/util';
+import listenOutsideClick from '../../../utils/listenOutsideClick';
 
 interface ITagType {
   name: string;
@@ -15,7 +15,7 @@ interface ITagType {
 }
 
 interface IDropdownProps extends ITagType {
-  handleCheckedTags: (id: string, isChecked: boolean) => void;
+  handleCheckedTags: (id: string, name: string, isChecked: boolean) => void;
 }
 
 function Dropdown({ name, elements, handleCheckedTags }: IDropdownProps) {

--- a/src/Organism/ProfileBox/index.tsx
+++ b/src/Organism/ProfileBox/index.tsx
@@ -24,6 +24,8 @@ import githubLogo from '../../assets/icons/github.svg';
 import { TechTagBox } from '../../Component/Box/TechTagBox';
 import { DoughnutChart } from '../../Component/Chart/DoughnutChart';
 import { createCategoryChartData } from '../../utils/createChartData';
+import { useNavigate } from 'react-router-dom';
+import { URL } from '../../constants/url';
 
 const CATEGORY_COLOR_MAP = [
   { category: 'OS', color: COLOR.POINT1 },
@@ -52,6 +54,7 @@ interface IProfileData {
 }
 
 export const ProfileBox = ({ profileData }: IProfileBox) => {
+  const navigate = useNavigate();
   const {
     nickname,
     imageUrl,
@@ -126,6 +129,9 @@ export const ProfileBox = ({ profileData }: IProfileBox) => {
         theme={BUTTON_THEME.SECONDARY}
         size={BUTTON_SIZE.LARGE_MEDIUM}
         className={editButtonStyle}
+        onClick={() => {
+          navigate(URL.USER_DATA_EDIT);
+        }}
       >
         프로필 수정하기
       </TextButton>

--- a/src/Organism/ProfileBox/index.tsx
+++ b/src/Organism/ProfileBox/index.tsx
@@ -27,13 +27,6 @@ import { createCategoryChartData } from '../../utils/createChartData';
 import { useNavigate } from 'react-router-dom';
 import { URL } from '../../constants/url';
 
-const CATEGORY_COLOR_MAP = [
-  { category: 'OS', color: COLOR.POINT1 },
-  { category: 'DB', color: COLOR.POINT2 },
-  { category: 'Data Structure', color: COLOR.POINT3 },
-  { category: 'Network', color: COLOR.POINT4 },
-];
-
 interface IProfileBox {
   profileData: IProfileData;
 }

--- a/src/Page/QuestionListPage/index.tsx
+++ b/src/Page/QuestionListPage/index.tsx
@@ -46,11 +46,11 @@ function QuestionListPage() {
   const [page, setPage] = useState(0);
   const { isLogin } = useAuthStore();
 
-  const handleCheckedTags = (id: string, isChecked: boolean) => {
+  const handleCheckedTags = (id: string, name: string, isChecked: boolean) => {
     setCheckedTags((prev) =>
       prev.map((tag) => tag.id).includes(id)
-        ? prev.map((tag) => (tag.id === id ? { id, isChecked } : tag))
-        : [...prev, { id, isChecked }],
+        ? prev.map((tag) => (tag.id === id ? { id, isChecked, name } : tag))
+        : [...prev, { id, isChecked, name }],
     );
   };
 

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -18,6 +18,8 @@ import { useEffect, useState } from 'react';
 import { createMajorList } from '../../utils/createMajorList';
 import { IMajorListElement } from '../../types/api/major';
 import { IDropdownElement } from '../../types/util';
+import { WarningMessage } from '../../Component/Message/WarningMessage';
+import { isPasswordConfirmed } from '../../utils/isPasswordConfirmed';
 
 const MAJOR_OPEN_API_KEY = '3da82601ae4e70ae3be5112a07bf35c5';
 const MAJOR_OPEN_API_URL = 'https://www.career.go.kr/cnet/openapi/getOpenApi.json';
@@ -45,17 +47,28 @@ export const UserDataEditPage = () => {
     getMajorList(majorSearchTitle),
   );
   const [majorList, setMajorList] = useState<IDropdownElement[]>([]);
+  const [isPasswordConfirmWarningShown, setIsPasswordConfirmWarningShown] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const searchMajor = () => {
     const majorInputValue = (document.getElementById('major') as HTMLInputElement).value;
     setMajorSearchTitle(majorInputValue);
   };
 
+  const confirmPassword = () => {
+    const password = (document.getElementById('password') as HTMLInputElement)?.value;
+    const passwordConfirm = (document.getElementById('password-confirm') as HTMLInputElement)
+      ?.value;
+    if (passwordConfirm) {
+      const result = isPasswordConfirmed(password, passwordConfirm);
+      setIsPasswordConfirmWarningShown(!result);
+      setIsFormValid(result);
+    }
+  };
+
   useEffect(() => {
     setMajorList(createMajorList(majorData));
   }, [majorData]);
-
-  const isPasswordConfirmed = (password1: string, password2: string) => password1 === password2;
 
   return (
     <PageTemplate>
@@ -77,7 +90,11 @@ export const UserDataEditPage = () => {
             name='password-confirm'
             placeholder='비밀번호를 다시 한번 입력해주세요'
             type={INPUT_TYPE.PASSWORD}
+            onChange={confirmPassword}
           />
+          <WarningMessage isShown={isPasswordConfirmWarningShown}>
+            비밀번호가 일치하지 않습니다.
+          </WarningMessage>
           <label htmlFor='major'>전공</label>
           <SearchDropdownInputBox id='major' elements={majorList} searchWithAPI={searchMajor} />
           <label htmlFor='job'>직업</label>
@@ -101,6 +118,7 @@ export const UserDataEditPage = () => {
             size={BUTTON_SIZE.LARGE}
             type={BUTTON_TYPE.SUBMIT}
             onClick={submit}
+            isActivated={isFormValid}
           >
             수정
           </TextButton>

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -1,5 +1,72 @@
+import { DefaultInputBox } from '../../Component/Box';
+import { SearchDropdownInputBox } from '../../Component/Box/InputBox/SearchDropdownInputBox.tsx';
+import { TextButton } from '../../Component/Button';
+import { INPUT_TYPE } from '../../constants/input';
 import { PageTemplate } from '../../Template';
+import { BUTTON_SIZE, BUTTON_THEME, BUTTON_TYPE } from '../../types/button';
+import {
+  formWrapperStyle,
+  pageWrapperStyle,
+  urlInputStyle,
+  urlPrefixStyle,
+  urlWrapperStyle,
+} from './style.css';
+import { CORE_TECH, JOB, JOB_OBJECTIVE } from '../../constants/userDataEdit';
 
 export const UserDataEditPage = () => {
-  return <PageTemplate>UserDataEditPage</PageTemplate>;
+  const submit = () => {};
+
+  const isPasswordConfirmed = (password1: string, password2: string) => password1 === password2;
+
+  return (
+    <PageTemplate>
+      <div className={pageWrapperStyle}>
+        <h1>정보수정</h1>
+        <form className={formWrapperStyle}>
+          <label htmlFor='nickname'>닉네임</label>
+          <DefaultInputBox id='nickname' name='nickname' placeholder='닉네임을 입력해주세요' />
+          <label htmlFor='password'>비밀번호</label>
+          <DefaultInputBox
+            id='password'
+            name='password'
+            placeholder='비밀번호를 입력해주세요'
+            type={INPUT_TYPE.PASSWORD}
+          />
+          <label htmlFor='password-confirm'>비밀번호 확인</label>
+          <DefaultInputBox
+            id='password-confirm'
+            name='password-confirm'
+            placeholder='비밀번호를 다시 한번 입력해주세요'
+            type={INPUT_TYPE.PASSWORD}
+          />
+          <label htmlFor='major'>전공</label>
+          <SearchDropdownInputBox id='major' elements={[]} />
+          <label htmlFor='job'>직업</label>
+          <SearchDropdownInputBox id='job' elements={JOB} />
+          <label htmlFor='core-tect'>주요 기술</label>
+          <SearchDropdownInputBox id='core-tect' elements={CORE_TECH} />
+          <label htmlFor='job-objective'>희망 직무</label>
+          <SearchDropdownInputBox id='job-objective' elements={JOB_OBJECTIVE} />
+          <label htmlFor='github-url'>Github</label>
+          <div className={urlWrapperStyle}>
+            <span className={urlPrefixStyle}>github.com/</span>
+            <input className={urlInputStyle} id='github-url' />
+          </div>
+          <label htmlFor='linkedin-url'>Linkedin</label>
+          <div className={urlWrapperStyle}>
+            <span className={urlPrefixStyle}>linkedin.com/</span>
+            <input className={urlInputStyle} id='linkedin-url' />
+          </div>
+          <TextButton
+            theme={BUTTON_THEME.PRIMARY}
+            size={BUTTON_SIZE.LARGE}
+            type={BUTTON_TYPE.SUBMIT}
+            onClick={submit}
+          >
+            수정
+          </TextButton>
+        </form>
+      </div>
+    </PageTemplate>
+  );
 };

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -41,7 +41,9 @@ export const UserDataEditPage = () => {
       .then((res) => res.data.dataSearch.content);
   };
 
-  const submit = () => {};
+  const submit = () => {
+    return;
+  };
   const [majorSearchTitle, setMajorSearchTitle] = useState<string | null>(null);
   const { data: majorData } = useQuery<IMajorListElement[]>(['majors', majorSearchTitle], () =>
     getMajorList(majorSearchTitle),

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -14,14 +14,17 @@ import {
 import { CORE_TECH, JOB, JOB_OBJECTIVE } from '../../constants/userDataEdit';
 import { useQuery } from 'react-query';
 import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { createMajorList } from '../../utils/createMajorList';
+import { IMajorListElement } from '../../types/api/major';
+import { IDropdownElement } from '../../types/util';
 
 const MAJOR_OPEN_API_KEY = '3da82601ae4e70ae3be5112a07bf35c5';
 const MAJOR_OPEN_API_URL = 'https://www.career.go.kr/cnet/openapi/getOpenApi.json';
 
 export const UserDataEditPage = () => {
-  const submit = () => {};
-  const { data } = useQuery('majors', () =>
-    axios
+  const getMajorList = (searchTitle?: string | null) => {
+    return axios
       .get(MAJOR_OPEN_API_URL, {
         params: {
           apiKey: MAJOR_OPEN_API_KEY,
@@ -29,10 +32,23 @@ export const UserDataEditPage = () => {
           svcCode: 'MAJOR',
           gubun: 'univ_list',
           contentType: 'json',
+          perPage: 5,
+          searchTitle: searchTitle,
         },
       })
-      .then((res) => res.data),
+      .then((res) => res.data.dataSearch.content);
+  };
+
+  const submit = () => {};
+  const [majorSearchTitle, setMajorSearchTItle] = useState<string | null>(null);
+  const { data: majorData } = useQuery<IMajorListElement[]>(['majors', majorSearchTitle], () =>
+    getMajorList(majorSearchTitle),
   );
+  const [majorList, setMajorList] = useState<IDropdownElement[]>([]);
+
+  useEffect(() => {
+    setMajorList(createMajorList(majorData));
+  }, [majorData]);
 
   const isPasswordConfirmed = (password1: string, password2: string) => password1 === password2;
 
@@ -58,7 +74,7 @@ export const UserDataEditPage = () => {
             type={INPUT_TYPE.PASSWORD}
           />
           <label htmlFor='major'>전공</label>
-          <SearchDropdownInputBox id='major' elements={[]} />
+          <SearchDropdownInputBox id='major' elements={majorList} />
           <label htmlFor='job'>직업</label>
           <SearchDropdownInputBox id='job' elements={JOB} />
           <label htmlFor='core-tect'>주요 기술</label>

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -21,15 +21,12 @@ import { IDropdownElement } from '../../types/util';
 import { WarningMessage } from '../../Component/Message/WarningMessage';
 import { isPasswordConfirmed } from '../../utils/isPasswordConfirmed';
 
-const MAJOR_OPEN_API_KEY = '3da82601ae4e70ae3be5112a07bf35c5';
-const MAJOR_OPEN_API_URL = 'https://www.career.go.kr/cnet/openapi/getOpenApi.json';
-
 export const UserDataEditPage = () => {
   const getMajorList = (searchTitle?: string | null) => {
     return axios
-      .get(MAJOR_OPEN_API_URL, {
+      .get(import.meta.env.VITE_MAJOR_OPEN_API_URL, {
         params: {
-          apiKey: MAJOR_OPEN_API_KEY,
+          apiKey: import.meta.env.VITE_MAJOR_OPEN_API_KEY,
           svcType: 'api',
           svcCode: 'MAJOR',
           gubun: 'univ_list',

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -12,9 +12,27 @@ import {
   urlWrapperStyle,
 } from './style.css';
 import { CORE_TECH, JOB, JOB_OBJECTIVE } from '../../constants/userDataEdit';
+import { useQuery } from 'react-query';
+import axios from 'axios';
+
+const MAJOR_OPEN_API_KEY = '3da82601ae4e70ae3be5112a07bf35c5';
+const MAJOR_OPEN_API_URL = 'https://www.career.go.kr/cnet/openapi/getOpenApi.json';
 
 export const UserDataEditPage = () => {
   const submit = () => {};
+  const { data } = useQuery('majors', () =>
+    axios
+      .get(MAJOR_OPEN_API_URL, {
+        params: {
+          apiKey: MAJOR_OPEN_API_KEY,
+          svcType: 'api',
+          svcCode: 'MAJOR',
+          gubun: 'univ_list',
+          contentType: 'json',
+        },
+      })
+      .then((res) => res.data),
+  );
 
   const isPasswordConfirmed = (password1: string, password2: string) => password1 === password2;
 

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -32,7 +32,7 @@ export const UserDataEditPage = () => {
           svcCode: 'MAJOR',
           gubun: 'univ_list',
           contentType: 'json',
-          perPage: 5,
+          perPage: 7,
           searchTitle: searchTitle,
         },
       })
@@ -40,11 +40,16 @@ export const UserDataEditPage = () => {
   };
 
   const submit = () => {};
-  const [majorSearchTitle, setMajorSearchTItle] = useState<string | null>(null);
+  const [majorSearchTitle, setMajorSearchTitle] = useState<string | null>(null);
   const { data: majorData } = useQuery<IMajorListElement[]>(['majors', majorSearchTitle], () =>
     getMajorList(majorSearchTitle),
   );
   const [majorList, setMajorList] = useState<IDropdownElement[]>([]);
+
+  const searchMajor = () => {
+    const majorInputValue = (document.getElementById('major') as HTMLInputElement).value;
+    setMajorSearchTitle(majorInputValue);
+  };
 
   useEffect(() => {
     setMajorList(createMajorList(majorData));
@@ -74,7 +79,7 @@ export const UserDataEditPage = () => {
             type={INPUT_TYPE.PASSWORD}
           />
           <label htmlFor='major'>전공</label>
-          <SearchDropdownInputBox id='major' elements={majorList} />
+          <SearchDropdownInputBox id='major' elements={majorList} searchWithAPI={searchMajor} />
           <label htmlFor='job'>직업</label>
           <SearchDropdownInputBox id='job' elements={JOB} />
           <label htmlFor='core-tect'>주요 기술</label>

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -19,7 +19,6 @@ import { createMajorList } from '../../utils/createMajorList';
 import { IMajorListElement } from '../../types/api/major';
 import { IDropdownElement } from '../../types/util';
 import { WarningMessage } from '../../Component/Message/WarningMessage';
-import { isPasswordConfirmed } from '../../utils/isPasswordConfirmed';
 
 export const UserDataEditPage = () => {
   const getMajorList = (searchTitle?: string | null) => {
@@ -59,7 +58,7 @@ export const UserDataEditPage = () => {
     const passwordConfirm = (document.getElementById('password-confirm') as HTMLInputElement)
       ?.value;
     if (passwordConfirm) {
-      const result = isPasswordConfirmed(password, passwordConfirm);
+      const result = password === passwordConfirm;
       setIsPasswordConfirmWarningShown(!result);
       setIsFormValid(result);
     }

--- a/src/Page/UserDataEditPage/index.tsx
+++ b/src/Page/UserDataEditPage/index.tsx
@@ -1,0 +1,5 @@
+import { PageTemplate } from '../../Template';
+
+export const UserDataEditPage = () => {
+  return <PageTemplate>UserDataEditPage</PageTemplate>;
+};

--- a/src/Page/UserDataEditPage/style.css.ts
+++ b/src/Page/UserDataEditPage/style.css.ts
@@ -1,0 +1,49 @@
+import { style } from '@vanilla-extract/css';
+import { COLOR } from '../../constants/color';
+import baseFontStyle from '../../styles/font.css';
+
+export const pageWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '3rem',
+});
+
+export const formWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  justifyContent: 'center',
+  gap: '1rem',
+
+  width: '31.25rem',
+});
+
+export const urlWrapperStyle = style([
+  baseFontStyle.small,
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+
+    width: '100%',
+    height: '4rem',
+
+    padding: '1rem',
+
+    border: '1px solid',
+    borderColor: COLOR.GRAY,
+    borderRadius: '10px',
+  },
+]);
+
+export const urlPrefixStyle = style({});
+
+export const urlInputStyle = style([
+  baseFontStyle.small,
+  {
+    width: '100%',
+    height: '100%',
+  },
+]);

--- a/src/Page/UserDataEditPage/style.css.ts
+++ b/src/Page/UserDataEditPage/style.css.ts
@@ -38,12 +38,16 @@ export const urlWrapperStyle = style([
   },
 ]);
 
-export const urlPrefixStyle = style({});
+export const urlPrefixStyle = style({
+  color: COLOR.GRAY,
+  cursor: 'default',
+});
 
 export const urlInputStyle = style([
   baseFontStyle.small,
   {
     width: '100%',
     height: '100%',
+    borderBottom: `1px solid ${COLOR.GRAY}`,
   },
 ]);

--- a/src/Page/index.ts
+++ b/src/Page/index.ts
@@ -10,6 +10,7 @@ import CallbackPage from './CallbackPage';
 import { LoginPage } from './LoginPage';
 import { ErrorPage } from './ErrorPage';
 import { MyPage } from './MyPage';
+import { UserDataEditPage } from './UserDataEditPage';
 
 export {
   MainPage,
@@ -24,4 +25,5 @@ export {
   LoginPage,
   ErrorPage,
   MyPage,
+  UserDataEditPage,
 };

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -13,6 +13,7 @@ import {
   LoginPage,
   ErrorPage,
   MyPage,
+  UserDataEditPage,
 } from './Page';
 
 function Router() {
@@ -29,6 +30,7 @@ function Router() {
         <Route path={URL.LOGIN} element={<LoginPage />} />
         <Route path={URL.NICKNAME} element={<NicknamePage />} />
         <Route path={URL.MYPAGE} element={<MyPage />} />
+        <Route path={URL.USER_DATA_EDIT} element={<UserDataEditPage />} />
         <Route path={URL.OAUTH_CALLBACK} element={<CallbackPage />} />
         <Route path={URL.ERROR} element={<ErrorPage />} />
       </Routes>

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,4 +1,3 @@
-import { ITag } from '../types/problem';
 import { ITagBox } from '../types/tag';
 import { IDropdownElement } from '../types/util';
 import { PROBLEM_TYPE } from './problem';

--- a/src/constants/tag.ts
+++ b/src/constants/tag.ts
@@ -1,10 +1,15 @@
 import { ITag } from '../types/problem';
 import { ITagBox } from '../types/tag';
+import { IDropdownElement } from '../types/util';
 import { PROBLEM_TYPE } from './problem';
+
+interface IDropdownElementWithColor extends IDropdownElement {
+  color: string;
+}
 
 interface ITagListElement {
   name: string;
-  elements: ITag[];
+  elements: IDropdownElementWithColor[];
 }
 
 const TAGLIST: ITagListElement[] = [

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -4,6 +4,7 @@ const URL = {
   LOGIN: '/login',
   NICKNAME: '/join/nickname',
   MYPAGE: '/mypage',
+  USER_DATA_EDIT: '/mypage/edit',
   PROBLEM_LIST: '/problem',
   LONG_PROBLEM_DETAIL: '/problem/long/:id',
   LONG_PROBLEM_RESULT: '/problem/long/result/:id',

--- a/src/constants/userDataEdit.ts
+++ b/src/constants/userDataEdit.ts
@@ -1,0 +1,21 @@
+export const JOB = [
+  { id: 'under-high-school', name: '고등학생 이하' },
+  { id: 'undergraduate', name: '대학생' },
+  { id: 'graduate', name: '대학원생' },
+  { id: 'developer', name: '직장인(개발자)' },
+  { id: 'not-developer', name: '직장인(비개발자)' },
+  { id: 'independent', name: '무소속(취업준비생)' },
+  { id: 'etc', name: '기타' },
+];
+
+export const CORE_TECH = [
+  { id: 'reactJS', name: 'ReactJS' },
+  { id: 'nodeJS', name: 'NodeJS' },
+  { id: 'java', name: 'Java' },
+];
+
+export const JOB_OBJECTIVE = [
+  { id: 'BACKEND', name: '서버/백엔드' },
+  { id: 'FRONTEND', name: '프론트엔드' },
+  { id: 'AI', name: '인공지능' },
+];

--- a/src/constants/userDataEdit.ts
+++ b/src/constants/userDataEdit.ts
@@ -1,4 +1,6 @@
-export const JOB = [
+import { IDropdownElement } from '../types/util';
+
+export const JOB: IDropdownElement[] = [
   { id: 'under-high-school', name: '고등학생 이하' },
   { id: 'undergraduate', name: '대학생' },
   { id: 'graduate', name: '대학원생' },
@@ -8,13 +10,13 @@ export const JOB = [
   { id: 'etc', name: '기타' },
 ];
 
-export const CORE_TECH = [
+export const CORE_TECH: IDropdownElement[] = [
   { id: 'reactJS', name: 'ReactJS' },
   { id: 'nodeJS', name: 'NodeJS' },
   { id: 'java', name: 'Java' },
 ];
 
-export const JOB_OBJECTIVE = [
+export const JOB_OBJECTIVE: IDropdownElement[] = [
   { id: 'BACKEND', name: '서버/백엔드' },
   { id: 'FRONTEND', name: '프론트엔드' },
   { id: 'AI', name: '인공지능' },

--- a/src/types/api/major.ts
+++ b/src/types/api/major.ts
@@ -1,0 +1,7 @@
+export interface IMajorListElement {
+  facilName: string;
+  lClass: string;
+  mClass: string;
+  majorSeq: string;
+  totalCount: string;
+}

--- a/src/types/box.ts
+++ b/src/types/box.ts
@@ -4,4 +4,5 @@ export interface IInputBox {
   type?: string;
   placeholder?: string;
   children?: JSX.Element | string;
+  onChange?: () => void;
 }

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -12,7 +12,7 @@ export interface IButton {
 export interface IButtonDetail extends IButton {
   theme: TButtonTheme;
   size: TButtonSize;
-  isActivated: boolean;
+  isActivated?: boolean;
 }
 
 export const BUTTON_TYPE = { SUBMIT: 'submit', BUTTON: 'button', RESET: 'reset' } as const;

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -12,6 +12,7 @@ export interface IButton {
 export interface IButtonDetail extends IButton {
   theme: TButtonTheme;
   size: TButtonSize;
+  isActivated: boolean;
 }
 
 export const BUTTON_TYPE = { SUBMIT: 'submit', BUTTON: 'button', RESET: 'reset' } as const;

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,6 +1,6 @@
 export interface ITagBox {
   name: string;
-  color?: 'color1' | 'color2' | 'color3' | 'color4';
+  color?: string;
 }
 
 export interface ITagState {

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,9 +1,10 @@
 export interface ITagBox {
   name: string;
-  color: 'color1' | 'color2' | 'color3' | 'color4';
+  color?: 'color1' | 'color2' | 'color3' | 'color4';
 }
 
 export interface ITagState {
   id: string;
+  name: string;
   isChecked: boolean;
 }

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,6 +1,7 @@
 interface IDropdownElement {
   id: string;
   name: string;
+  color?: string;
 }
 
 export type { IDropdownElement };

--- a/src/utils/createMajorList.ts
+++ b/src/utils/createMajorList.ts
@@ -1,0 +1,13 @@
+import { IDropdownElement } from '../types/util';
+import { IMajorListElement } from './../types/api/major';
+
+export const createMajorList = (
+  apiResponse: IMajorListElement[] | undefined,
+): IDropdownElement[] => {
+  if (!apiResponse) return [];
+
+  const data = apiResponse.map(
+    (major) => ({ id: major.majorSeq, name: major.mClass } as IDropdownElement),
+  );
+  return data;
+};

--- a/src/utils/isPasswordConfirmed.ts
+++ b/src/utils/isPasswordConfirmed.ts
@@ -1,2 +1,0 @@
-export const isPasswordConfirmed = (password1: string, password2: string) =>
-  password1 === password2;

--- a/src/utils/isPasswordConfirmed.ts
+++ b/src/utils/isPasswordConfirmed.ts
@@ -1,0 +1,2 @@
+export const isPasswordConfirmed = (password1: string, password2: string) =>
+  password1 === password2;

--- a/src/utils/listenOutsideClick.ts
+++ b/src/utils/listenOutsideClick.ts
@@ -5,16 +5,14 @@ export default function listenOutsideClick( //menuRef가 가르키는 dom요소(
   menuRef: RefObject<HTMLDivElement>,
   setIsOpen: (isOpen: boolean) => void,
 ) {
-  return () => {
-    if (!menuRef.current) return;
+  if (!menuRef.current) return;
 
-    [EVENT.CLICK, EVENT.TOUCHSTART].forEach((e) => {
-      document.addEventListener(e, (event) => {
-        const curr = menuRef.current;
-        const target = event.target;
-        if (curr?.contains(target as Node)) return;
-        setIsOpen(false);
-      });
+  [EVENT.CLICK, EVENT.TOUCHSTART].forEach((e) => {
+    document.addEventListener(e, (event) => {
+      const curr = menuRef.current;
+      const target = event.target;
+      if (curr?.contains(target as Node)) return;
+      setIsOpen(false);
     });
-  };
+  });
 }

--- a/src/utils/listenOutsideClick.ts
+++ b/src/utils/listenOutsideClick.ts
@@ -1,5 +1,5 @@
 import { RefObject } from 'react';
-import { EVENT } from '../../constants';
+import { EVENT } from '../constants';
 
 export default function listenOutsideClick( //menuRef가 가르키는 dom요소(드롭다운)가 아닌 곳이 클릭되면 isOpen false로
   menuRef: RefObject<HTMLDivElement>,


### PR DESCRIPTION
### 작업 내역

> 구현 내용 및 작업 했던 내역
<img width="1072" alt="스크린샷 2022-09-06 오후 12 24 09" src="https://user-images.githubusercontent.com/63906230/188540536-e37be0ba-2e78-4f8b-94c6-c9f7cb27b8d6.png">

- [x] 정보수정페이지 UI 구현
- [x] 비밀번호 확인 기능
- [x] 전공은 [커리어넷 open API](https://www.career.go.kr/cnet/front/openapi/openApiMajorCenter.do) 활용하였으나 검색이 이상해서 공공데이터포털 등에서 제공하는 것으로 바꿀지 고민중
- [x] 직업, 주요기술, 희망직무는 현재 constant로 갖고있음
- [x] 이미지 업로드까지 구현하고 올리면 한세월일 것 같아 지금 올립니다.

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- UserDataEditPage에서 다른 요소들은 constant라 하위 컴포넌트에서 데이터를 관리할 수 있는데 전공은 api를 페이지단에서 불러 상태로 관리하여 좋은 구조가 아니라 생각됨. 추후에 api를 호출해올 요소가 더 많아질 것이라는 점에서 더욱 그러함. 하지만 일단 구현함.. 
