### PR TITLE
MSTR-337: 객관식 문제풀이 페이지 UI 업데이트

### DIFF
--- a/src/Component/Input/Checkbox/index.tsx
+++ b/src/Component/Input/Checkbox/index.tsx
@@ -1,0 +1,17 @@
+import { INPUT_TYPE } from '../../../constants/input';
+import './style.css';
+
+interface ICheckbox {
+  id: string;
+  label: string;
+  name: string;
+}
+
+export const Checkbox = ({ id, label, name }: ICheckbox) => {
+  return (
+    <label htmlFor={id} className='checkBoxWrapperStyle'>
+      <input type={INPUT_TYPE.CHECKBOX} id={id} name={name} className='checkboxStyle' />
+      <span className='labelTextStyle'>{label}</span>
+    </label>
+  );
+};

--- a/src/Component/Input/Checkbox/style.css
+++ b/src/Component/Input/Checkbox/style.css
@@ -1,0 +1,51 @@
+.checkBoxWrapperStyle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  cursor: pointer;
+}
+
+input[type='checkbox'].checkboxStyle {
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: #eee;
+  margin: 0;
+
+  font: inherit;
+  color: #eee;
+  width: 20px;
+  height: 20px;
+  border: 2px solid currentColor;
+  border-radius: 2px;
+
+  display: grid;
+  place-content: center;
+
+  cursor: pointer;
+}
+
+input[type='checkbox'].checkboxStyle:checked {
+  background-color: #2a7af3;
+  color: #2a7af3;
+}
+
+input[type='checkbox'].checkboxStyle::before {
+  content: '';
+  width: 0.55em;
+  height: 0.55em;
+  clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+  transform: scale(0);
+  transform-origin: center;
+  transition: 100ms transform ease-in-out;
+  background-color: #fff;
+}
+
+input[type='checkbox'].checkboxStyle:checked::before {
+  transform: scale(1);
+}
+
+.labelTextStyle {
+  max-width: 90%;
+  word-wrap: break-word;
+}

--- a/src/Component/Input/Checkbox/style.css
+++ b/src/Component/Input/Checkbox/style.css
@@ -14,8 +14,8 @@ input[type='checkbox'].checkboxStyle {
 
   font: inherit;
   color: #eee;
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border: 2px solid currentColor;
   border-radius: 2px;
 

--- a/src/Component/Input/RadioButton/index.tsx
+++ b/src/Component/Input/RadioButton/index.tsx
@@ -1,0 +1,17 @@
+import { INPUT_TYPE } from '../../../constants/input';
+import './style.css';
+
+interface IRadioButton {
+  id: string;
+  label: string;
+  name: string;
+}
+
+export const RadioButton = ({ id, label, name }: IRadioButton) => {
+  return (
+    <label htmlFor={id} className='radioButtonWrapperStyle'>
+      <input type={INPUT_TYPE.RADIO} id={id} name={name} className='radioButtonStyle' />
+      <span className='labelTextStyle'>{label}</span>
+    </label>
+  );
+};

--- a/src/Component/Input/RadioButton/style.css
+++ b/src/Component/Input/RadioButton/style.css
@@ -1,0 +1,52 @@
+label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  cursor: pointer;
+}
+
+input[type='radio'] {
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: #eee;
+  margin: 0;
+
+  font: inherit;
+  color: #eee;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+
+  display: grid;
+  place-content: center;
+
+  cursor: pointer;
+}
+
+input[type='radio']:checked {
+  background-color: #2a7af3;
+  color: #2a7af3;
+}
+
+input[type='radio']::before {
+  content: '';
+  width: 0.45em;
+  height: 0.45em;
+  border-radius: 50%;
+  /* clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%); */
+  transform: scale(0);
+  transform-origin: center;
+  transition: 100ms transform ease-in-out;
+  background-color: #fff;
+}
+
+input[type='radio']:checked::before {
+  transform: scale(1);
+}
+
+.labelTextStyle {
+  max-width: 90%;
+  word-wrap: break-word;
+}

--- a/src/Page/JoinPage/index.tsx
+++ b/src/Page/JoinPage/index.tsx
@@ -95,7 +95,7 @@ function JoinPage() {
               }
               warningMessages={[
                 {
-                  text: '영문/숫자/특수문자 각각 한개 이상 포함',
+                  text: '영문/숫자/특수문자 각각 한 개 이상 포함',
                   isWarning: !isPasswordElementsValidate,
                 },
                 {

--- a/src/Page/QuestionDetailPage/Multiple/index.tsx
+++ b/src/Page/QuestionDetailPage/Multiple/index.tsx
@@ -6,17 +6,20 @@ import {
   IMultipleProblemResultData,
 } from '../../../types/api/problem';
 import {
-  choiceCheckboxStyle,
   choiceListStyle,
-  choiceWrapperStyle,
   contentTitleStyle,
   isMultipleAnswerStyle,
+  rightSideBottomContentWrapperStyle,
+  rightSideContentWrapperStyle,
+  rightSideTopContentWrapperStyle,
 } from './style.css';
 import { useQuery } from 'react-query';
 import { SplitProblemDetailPageTemplate } from '../../../Template/SplitProblemDetailPageTemplate';
 import { MetaTag } from '../../utils/MetaTag';
 import { ProblemDescriptionBox } from '../../../Component/Box/ProblemDescriptionBox';
 import { ResultBox } from '../../../Component/Box/ResultBox';
+import { Checkbox } from '../../../Component/Input/Checkbox';
+import { RadioButton } from '../../../Component/Input/RadioButton';
 
 export function MultipleQuestionDetailPage() {
   const { id } = useParams();
@@ -66,41 +69,47 @@ export function MultipleQuestionDetailPage() {
         isSubmittable={true}
         leftSideContent={<ProblemDescriptionBox>{data?.description}</ProblemDescriptionBox>}
         rightSideContent={
-          <>
-            <label htmlFor='answer' className={contentTitleStyle}>
-              답안 선택
-              <span className={isMultipleAnswerStyle}>
-                {data?.isMultipleAnswer ? ' (복수 선택)' : ' (정답 한개)'}
-              </span>
-            </label>
-            <div className={choiceListStyle} onClick={resetResult}>
-              {data?.choices.map((choice) => (
-                <label
-                  htmlFor={choice.id.toString()}
-                  className={choiceWrapperStyle}
-                  key={choice.id}
-                >
-                  <input
-                    type={data?.isMultipleAnswer ? 'checkbox' : 'radio'}
-                    id={choice.id.toString()}
-                    className={choiceCheckboxStyle}
-                    name='answer'
-                  />
-                  {choice.content}
-                </label>
-              ))}
+          <div className={rightSideContentWrapperStyle}>
+            <div className={rightSideTopContentWrapperStyle}>
+              <label htmlFor='answer' className={contentTitleStyle}>
+                답안 선택
+                <span className={isMultipleAnswerStyle}>
+                  {data?.isMultipleAnswer ? ' (복수 선택)' : ' (정답 한개)'}
+                </span>
+              </label>
+              <div className={choiceListStyle} onClick={resetResult}>
+                {data?.isMultipleAnswer
+                  ? data?.choices.map((choice) => (
+                      <Checkbox
+                        key={choice.id}
+                        id={choice.id.toString()}
+                        label={choice.content}
+                        name='answer'
+                      />
+                    ))
+                  : data?.choices.map((choice) => (
+                      <RadioButton
+                        key={choice.id}
+                        id={choice.id.toString()}
+                        label={choice.content}
+                        name='answer'
+                      />
+                    ))}
+              </div>
             </div>
-            {result ? (
-              <ResultBox
-                isCorrect={result.isAnswer}
-                score={result.score}
-                onClick={resetResult}
-                text={result.isAnswer ? '정답입니다' : '오답입니다'}
-              />
-            ) : (
-              <></>
-            )}
-          </>
+            <div className={rightSideBottomContentWrapperStyle}>
+              {result ? (
+                <ResultBox
+                  isCorrect={result.isAnswer}
+                  score={result.score}
+                  onClick={resetResult}
+                  text={result.isAnswer ? '정답입니다' : '오답입니다'}
+                />
+              ) : (
+                <></>
+              )}
+            </div>
+          </div>
         }
       ></SplitProblemDetailPageTemplate>
     </>

--- a/src/Page/QuestionDetailPage/Multiple/index.tsx
+++ b/src/Page/QuestionDetailPage/Multiple/index.tsx
@@ -74,7 +74,7 @@ export function MultipleQuestionDetailPage() {
               <label htmlFor='answer' className={contentTitleStyle}>
                 답안 선택
                 <span className={isMultipleAnswerStyle}>
-                  {data?.isMultipleAnswer ? ' (복수 선택)' : ' (정답 한개)'}
+                  {data?.isMultipleAnswer ? ' (복수 선택)' : ' (정답 한 개)'}
                 </span>
               </label>
               <div className={choiceListStyle} onClick={resetResult}>

--- a/src/Page/QuestionDetailPage/Multiple/style.css.ts
+++ b/src/Page/QuestionDetailPage/Multiple/style.css.ts
@@ -98,3 +98,22 @@ export const isMultipleAnswerStyle = style({
   fontSize: '1rem',
   lineHeight: '1.5rem',
 });
+
+export const rightSideContentWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  gap: '1.5rem',
+  height: '100%',
+});
+
+export const rightSideTopContentWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+});
+
+export const rightSideBottomContentWrapperStyle = style({
+  display: 'flex',
+  alignSelf: 'flex-end',
+});

--- a/src/Template/SplitProblemDetailPageTemplate/style.css.ts
+++ b/src/Template/SplitProblemDetailPageTemplate/style.css.ts
@@ -11,11 +11,9 @@ export const splitStyle = style({
 export const contentWrapperStyle = style({
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'flex-start',
-  justifyContent: 'flex-start',
   gap: '1.5rem',
-
   padding: '2rem 0 2rem 2rem',
+  minHeight: 'fit-content',
   minWidth: '21.875rem',
 });
 


### PR DESCRIPTION
### 작업 내역

> 구현 내용 및 작업 했던 내역

#### 체크박스 (복수선택)
![ezgif com-gif-maker (11)](https://user-images.githubusercontent.com/63906230/201032916-f95a61c7-aba2-4833-925b-ba81d7ebaff1.gif)

#### 라디오버튼 (단일선택)
![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/63906230/201032941-170e4c1f-aad9-4242-ad3a-0f1509640eb0.gif)


- [x] checkbox, radio button 커스텀
- [x] 객관식 문제풀이 페이지 UI 업데이트

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 저번에 통일성을 위해 체크박스, 라디오버튼을 모두 없앤다는 이야기를 했었는데요, 주변 유저들에게 설문조사를 해보니 체크박스, 라디오버튼이 있는 편이 더 직관적이라는 피드백을 들어서 유지하기로 했습니다. 대신에 브라우저 기본 UI를 제거하고 커스텀해서 넣었답니다~!
- 그러나 커스텀하는 과정에서 selector 사용이 많이 필요했는데, vanilla-extract는 selector를 자유롭게 사용하기 어려워서 pure css를 사용했습니다~! 두개가 서로 영향을 줄까봐 걱정했는데 찾아보니 다행히 그렇지 않다고 하네요!
