### PR TITLE
MSTR-373: 서술형 채점 버튼에 베타 태그 + 정답보기 기능

### DIFF
--- a/src/Component/Button/CustomButton/index.tsx
+++ b/src/Component/Button/CustomButton/index.tsx
@@ -1,9 +1,13 @@
 import { ICustomButton } from '../../../types/button';
+import { buttonTagStyle, customButtonWrapperStyle } from './style.css';
 
-export const CustomButton = ({ onClick, children, type, className }: ICustomButton) => {
+export const CustomButton = ({ onClick, children, type, className, tag }: ICustomButton) => {
   return (
-    <button type={type} onClick={onClick} className={className}>
-      {children}
-    </button>
+    <div className={customButtonWrapperStyle}>
+      {tag ? <div className={buttonTagStyle}>{tag}</div> : <></>}
+      <button type={type} onClick={onClick} className={`${className}`}>
+        {children}
+      </button>
+    </div>
   );
 };

--- a/src/Component/Button/CustomButton/style.css.ts
+++ b/src/Component/Button/CustomButton/style.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+import { COLOR } from '../../../constants/color';
+
+export const customButtonWrapperStyle = style({
+  position: 'relative',
+});
+
+export const buttonTagStyle = style({
+  position: 'absolute',
+  top: '-.7rem',
+  right: '-1.25rem',
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  width: '3rem',
+  height: '1.5rem',
+  padding: '.5rem',
+
+  border: `1px solid ${COLOR.GREEN}`,
+  borderRadius: '12px',
+  backgroundColor: COLOR.BACKGROUND.GREEN,
+  color: COLOR.GREEN,
+
+  textAlign: 'center',
+  fontWeight: '600',
+  fontSize: '.75rem',
+
+  zIndex: 1,
+});

--- a/src/Component/Button/TextButton/index.tsx
+++ b/src/Component/Button/TextButton/index.tsx
@@ -7,6 +7,7 @@ interface ITextButton extends ICustomButton {
   size: TButtonSize;
   isActivated?: boolean;
   className?: string;
+  tag?: string;
 }
 
 function TextButton({
@@ -16,6 +17,7 @@ function TextButton({
   onClick,
   children,
   className,
+  tag,
   isActivated = true,
 }: ITextButton) {
   return (
@@ -31,6 +33,7 @@ function TextButton({
       className={`${className} ${textButtonThemeStyle[theme]} ${textButtonSizeStyle[size]} ${
         !isActivated ? unactivatedStyle : ''
       } `}
+      tag={tag}
     >
       {children}
     </CustomButton>

--- a/src/Component/Utils/DropdownElement/index.tsx
+++ b/src/Component/Utils/DropdownElement/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEvent } from 'react';
+import { MouseEvent } from 'react';
 import { COLOR } from '../../../constants/color';
 import { INPUT_TYPE } from '../../../constants/input';
 import { Checkbox } from '../../../Icon/Checkbox';
@@ -25,26 +25,22 @@ export function DropdownElement({
   isChecked = false,
   isCheckbox = false,
 }: IDropdownComponentProps) {
-  function checkHandler({ target }: ChangeEvent<HTMLInputElement>) {
-    handleCheckedTags(target.id, target.name, target.checked);
-  }
   const onCheckboxClick = (event: MouseEvent<HTMLSpanElement>) => {
     event.stopPropagation();
-    const inputElement = event.currentTarget.previousSibling as HTMLInputElement;
+    const inputElement = event.currentTarget.firstChild as HTMLInputElement;
     handleCheckedTags(inputElement.id, inputElement.name, !isChecked);
     inputElement.checked = !isChecked;
   };
 
   return (
-    <li className={dropdownContentElementStyle}>
+    <li className={dropdownContentElementStyle} onClick={onCheckboxClick}>
       <input
         type={isCheckbox ? INPUT_TYPE.CHECKBOX : INPUT_TYPE.RADIO}
         name={name}
         id={id}
-        onChange={checkHandler}
         className={checkboxDefaultStyle}
       />
-      <span className={checkboxStyle} onClick={onCheckboxClick}>
+      <span className={checkboxStyle}>
         {isChecked ? (
           <CheckboxChecked
             width='1.25rem'
@@ -61,11 +57,7 @@ export function DropdownElement({
           />
         )}
       </span>
-
-      <label
-        htmlFor={id}
-        className={isChecked ? labelIsCheckedStyle.true : labelIsCheckedStyle.false}
-      >
+      <label className={isChecked ? labelIsCheckedStyle.true : labelIsCheckedStyle.false}>
         {name}
       </label>
     </li>

--- a/src/Page/LongProblemAnswerPage/index.tsx
+++ b/src/Page/LongProblemAnswerPage/index.tsx
@@ -36,7 +36,7 @@ export const LongProblemAnswerPage = () => {
       <MetaTag title='CS Broker - 정답' />
       <SplitProblemDetailPageTemplate
         sizes={[50, 50]}
-        data={result}
+        data={{ ...result, isSolved: true }}
         handleSubmit={() => {
           return;
         }}

--- a/src/Page/LongProblemAnswerPage/index.tsx
+++ b/src/Page/LongProblemAnswerPage/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useMutation } from 'react-query';
+import { useLocation, useParams } from 'react-router-dom';
+import { problemApiWrapper } from '../../api/wrapper/problem/problemApiWrapper';
+import { TextBox } from '../../Component/Box';
+import { SkeletonLongProblemResultPage } from '../../Component/Skeleton/SkeletonLongProblemResultPage';
+import { INVALID_ID_ERROR } from '../../errors';
+import { SplitProblemDetailPageTemplate } from '../../Template/SplitProblemDetailPageTemplate';
+import { ILongProblemResultData } from '../../types/api/problem';
+import { ILongProblemResultLocationState } from '../../types/problem';
+import { StandardAnswerContent } from '../ResultPage/Content/StandardAnswer';
+import { answerContentStyle, contentStyle, subtitleStyle } from '../ResultPage/style.css';
+import { MetaTag } from '../utils/MetaTag';
+
+export const LongProblemAnswerPage = () => {
+  const { id } = useParams();
+  const { userAnswer, title } = useLocation().state as ILongProblemResultLocationState;
+  const { data: result, isLoading, mutate } = useMutation<ILongProblemResultData>(handleSubmit);
+
+  function handleSubmit() {
+    if (!id) throw INVALID_ID_ERROR;
+    return problemApiWrapper.longProblemResult(id, userAnswer);
+  }
+
+  useEffect(() => {
+    mutate();
+  }, []);
+
+  if (isLoading)
+    return (
+      <SkeletonLongProblemResultPage title={title} userAnswer={userAnswer} id={id!} tags={[]} />
+    );
+
+  return (
+    <>
+      <MetaTag title='CS Broker - 정답' />
+      <SplitProblemDetailPageTemplate
+        sizes={[50, 50]}
+        data={result}
+        handleSubmit={() => {
+          return;
+        }}
+        isResult={true}
+        isResultPage={true}
+        leftSideContent={<StandardAnswerContent result={result} />}
+        rightSideContent={
+          <div className={contentStyle}>
+            <h3 className={subtitleStyle}>내 답안</h3>
+            <TextBox className={answerContentStyle}>{userAnswer}</TextBox>
+          </div>
+        }
+      />
+    </>
+  );
+};

--- a/src/Page/LongProblemAnswerPage/style.css.ts
+++ b/src/Page/LongProblemAnswerPage/style.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const userAnswerWrapperStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+});

--- a/src/Page/QuestionDetailPage/Long/index.tsx
+++ b/src/Page/QuestionDetailPage/Long/index.tsx
@@ -36,6 +36,15 @@ export function LongQuestionDetailPage() {
     refetch();
   };
 
+  const getAnswerWithoutSubmit = () => {
+    if (!id) throw INVALID_ID_ERROR;
+    localStorage.removeItem(LONG_PROBLEM_ANSWER(id));
+    navigate(URLWithParam.LONG_PROBLEM_ANSWER(parseInt(id)), {
+      state: { userAnswer: userAnswer, title: data?.title } as ILongProblemResultLocationState,
+    });
+    refetch();
+  };
+
   const onTextAreaChange = (event: KeyboardEvent) => {
     const userAnswerValue = (event.target as HTMLTextAreaElement).value;
     setUserAnswer(userAnswerValue);
@@ -54,7 +63,9 @@ export function LongQuestionDetailPage() {
         <SplitProblemDetailPageTemplate
           data={data}
           handleSubmit={handleSubmit}
+          getAnswerWithoutSubmit={getAnswerWithoutSubmit}
           isSubmittable={userAnswer?.length >= 10}
+          isLong={true}
           leftSideContent={<ProblemDescriptionBox>{data?.description}</ProblemDescriptionBox>}
           rightSideContent={
             <LongProblemTextArea userAnswer={userAnswer} onTextAreaChange={onTextAreaChange} />

--- a/src/Page/ResultPage/Content/StandardAnswer/index.tsx
+++ b/src/Page/ResultPage/Content/StandardAnswer/index.tsx
@@ -1,13 +1,7 @@
 import { TextBox } from '../../../../Component/Box';
 import { MarkdownBox } from '../../../../Component/Box/MarkdownBox';
-import { MyScoreBox } from '../../../../Component/Box/MyScoreBox';
 import { ILongProblemResult } from '../../../../types/problem';
-import {
-  contentStyle,
-  myScoreStyle,
-  standardAnswerContentStyle,
-  subtitleStyle,
-} from '../../style.css';
+import { contentStyle, standardAnswerContentStyle, subtitleStyle } from '../../style.css';
 
 export const StandardAnswerContent = ({ result }: ILongProblemResult) => {
   return (
@@ -18,7 +12,6 @@ export const StandardAnswerContent = ({ result }: ILongProblemResult) => {
           <MarkdownBox>{result?.standardAnswer}</MarkdownBox>
         </div>
       </TextBox>
-      <MyScoreBox score={result?.score} className={myScoreStyle} />
     </div>
   );
 };

--- a/src/Page/ResultPage/Content/UserAnswer/index.tsx
+++ b/src/Page/ResultPage/Content/UserAnswer/index.tsx
@@ -1,4 +1,5 @@
 import { KeywordBox, TextBox } from '../../../../Component/Box';
+import { MyScoreBox } from '../../../../Component/Box/MyScoreBox';
 import { USER_ANSWER_DOM_ID } from '../../../../constants/longProblem';
 import { ILongProblemResult } from '../../../../types/problem';
 import { ResultAssessment } from '../../components/ResultAssessment';
@@ -8,6 +9,7 @@ import {
   contentListStyle,
   contentStyle,
   keywordListStyle,
+  myScoreStyle,
   subtitleStyle,
 } from '../../style.css';
 
@@ -16,6 +18,7 @@ export const UserAnswerContent = ({ result }: ILongProblemResult) => {
     <div className={contentStyle}>
       <h3 className={subtitleStyle}>내 답안</h3>
       <TextBox id={USER_ANSWER_DOM_ID} className={answerContentStyle} />
+      <MyScoreBox score={result?.score} className={myScoreStyle} />
       <h4>키워드 채점 기준</h4>
       <ul className={keywordListStyle}>
         {result?.keywords?.map(({ id, content, isExist }) => (

--- a/src/Page/ResultPage/components/ResultAssessment/index.tsx
+++ b/src/Page/ResultPage/components/ResultAssessment/index.tsx
@@ -76,7 +76,6 @@ export const ResultAssessment = ({ gradingHistoryId }: IAssessmentPopover) => {
                   } else {
                     handleAssessmentSubmit(e.value);
                   }
-                  handleClick(event);
                 }}
                 key={e.value}
               >

--- a/src/Page/ResultPage/index.tsx
+++ b/src/Page/ResultPage/index.tsx
@@ -45,7 +45,7 @@ export default function ResultPage() {
       <MetaTag title='CS Broker - 채점 결과' />
       <SplitProblemDetailPageTemplate
         sizes={[50, 50]}
-        data={result}
+        data={{ ...result, isSolved: true }}
         handleSubmit={handleSubmit}
         isResult={true}
         isResultPage={true}

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -27,6 +27,7 @@ import { ProtectedLayout } from './ProtectedLayout';
 import { PublicLayout } from './PublicLayout';
 import { PageTemplate } from '../Template';
 import { DescriptionPage } from '../Page/DescriptionPage';
+import { LongProblemAnswerPage } from '../Page/LongProblemAnswerPage';
 
 function Router() {
   return (
@@ -51,6 +52,7 @@ function Router() {
           <Route path={URL.PROBLEM_LIST} element={<QuestionListPage />} />
           <Route path={URL.PROBLEM_SET_LIST} element={<ProblemSetListPage />} />
           <Route path={URL.LONG_PROBLEM_DETAIL} element={<LongQuestionDetailPage />} />
+          <Route path={URL.LONG_PROBLEM_ANSWER} element={<LongProblemAnswerPage />} />
           <Route path={URL.SHORT_PROBLEM_DETAIL} element={<ShortQuestionDetailPage />} />
           <Route path={URL.MULTIPLE_PROBLEM_DETAIL} element={<MultipleQuestionDetailPage />} />
           <Route path={URL.PROBLEM_SET_DETAIL} element={<ProblemSetDetailPage />} />

--- a/src/Template/ProblemDetailPageTemplate/ButtonList/Problem/index.tsx
+++ b/src/Template/ProblemDetailPageTemplate/ButtonList/Problem/index.tsx
@@ -7,20 +7,24 @@ import { buttonListStyle, buttonListWrapperStyle } from '../../style.css';
 
 interface IProblemDetailButtonList {
   handleSubmit?: () => void;
+  getAnswerWithoutSubmit?: () => void;
   isResult?: boolean;
   resetResult?: () => void;
   isResultPage?: boolean;
   isSubmittable?: boolean;
+  isLong?: boolean;
 }
 
 export const ProblemDetailButtonList = ({
   handleSubmit,
+  getAnswerWithoutSubmit,
   isResult = false,
   resetResult = () => {
     return;
   },
   isResultPage = false,
   isSubmittable = false,
+  isLong = false,
 }: IProblemDetailButtonList) => {
   const navigate = useNavigate();
   return (
@@ -37,6 +41,7 @@ export const ProblemDetailButtonList = ({
           >
             돌아가기
           </TextButton>
+
           {getUserInfo() ? (
             isResult ? (
               <TextButton
@@ -49,6 +54,28 @@ export const ProblemDetailButtonList = ({
               >
                 다시풀기
               </TextButton>
+            ) : isLong ? (
+              <>
+                <TextButton
+                  type={BUTTON_TYPE.BUTTON}
+                  theme={BUTTON_THEME.TERTIARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                  onClick={getAnswerWithoutSubmit}
+                  isActivated={isSubmittable}
+                >
+                  정답보기
+                </TextButton>
+                <TextButton
+                  type={BUTTON_TYPE.SUBMIT}
+                  theme={BUTTON_THEME.PRIMARY}
+                  size={BUTTON_SIZE.MEDIUM}
+                  onClick={handleSubmit}
+                  isActivated={isSubmittable}
+                  tag='Beta'
+                >
+                  AI 채점하기
+                </TextButton>
+              </>
             ) : (
               <TextButton
                 type={BUTTON_TYPE.SUBMIT}

--- a/src/Template/ProblemDetailPageTemplate/index.tsx
+++ b/src/Template/ProblemDetailPageTemplate/index.tsx
@@ -14,6 +14,7 @@ export const ProblemDetailPageTemplate = ({
   data,
   children,
   handleSubmit,
+  getAnswerWithoutSubmit,
   bottomContent,
   isResult = false,
   resetResult = () => {
@@ -21,6 +22,7 @@ export const ProblemDetailPageTemplate = ({
   },
   isResultPage = false,
   isSubmittable = false,
+  isLong = false,
 }: IProblemDetailPageTemplate) => {
   const { id } = useParams();
 
@@ -51,10 +53,12 @@ export const ProblemDetailPageTemplate = ({
               <div className={questionContentStyle}>{children}</div>
               <ProblemDetailButtonList
                 handleSubmit={handleSubmit}
+                getAnswerWithoutSubmit={getAnswerWithoutSubmit}
                 isResult={isResult}
                 resetResult={resetResult}
                 isResultPage={isResultPage}
                 isSubmittable={isSubmittable}
+                isLong={isLong}
               />
             </div>
             <div className={bottomContentStyle}>{bottomContent}</div>

--- a/src/Template/SplitProblemDetailPageTemplate/index.tsx
+++ b/src/Template/SplitProblemDetailPageTemplate/index.tsx
@@ -9,21 +9,25 @@ export const SplitProblemDetailPageTemplate = ({
   rightSideContent,
   bottomContent,
   handleSubmit,
+  getAnswerWithoutSubmit,
   isResult,
   resetResult,
   isResultPage,
   isSubmittable = false,
+  isLong = false,
   sizes = [35, 65],
 }: ISplitProblemDetailPageTemplate) => {
   return (
     <ProblemDetailPageTemplate
       data={data}
       handleSubmit={handleSubmit}
+      getAnswerWithoutSubmit={getAnswerWithoutSubmit}
       isResult={isResult}
       resetResult={resetResult}
       isResultPage={isResultPage}
       bottomContent={bottomContent}
       isSubmittable={isSubmittable}
+      isLong={isLong}
     >
       <CustomSplit
         sizes={sizes}

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -11,6 +11,7 @@ const URL = {
   PROBLEM_SET_LIST: '/problem-set',
   LONG_PROBLEM_DETAIL: '/problem/long/:id',
   LONG_PROBLEM_RESULT: '/problem/long/result/:id',
+  LONG_PROBLEM_ANSWER: '/problem/long/answer/:id',
   SHORT_PROBLEM_DETAIL: '/problem/short/:id',
   SHORT_PROBLEM_RESULT: '/problem/short/result/:id',
   MULTIPLE_PROBLEM_DETAIL: '/problem/multiple/:id',
@@ -27,6 +28,7 @@ const URL = {
 const URLWithParam = {
   LONG_PROBLEM_DETAIL: (id: number) => `/problem/long/${id}`,
   LONG_PROBLEM_RESULT: (id: number) => `/problem/long/result/${id}`,
+  LONG_PROBLEM_ANSWER: (id: number) => `/problem/long/answer/${id}`,
   SHORT_PROBLEM_DETAIL: (id: number) => `/problem/short/${id}`,
   SHORT_PROBLEM_RESULT: (id: number) => `/problem/short/result/${id}`,
   MULTIPLE_PROBLEM_DETAIL: (id: number) => `/problem/multiple/${id}`,

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -41,4 +41,5 @@ export interface ICustomButton {
   type?: TButtonType;
   children?: React.ReactNode;
   className?: string;
+  tag?: string;
 }

--- a/src/types/problem.ts
+++ b/src/types/problem.ts
@@ -60,12 +60,14 @@ interface IProblemDetailPageTemplate {
   data: TPartialProblemDetailResponseData | undefined;
   children?: React.ReactNode;
   handleSubmit?: () => void;
+  getAnswerWithoutSubmit?: () => void;
   isResult?: boolean;
   isProblemSet?: boolean;
   resetResult?: () => void;
   isResultPage?: boolean;
   bottomContent?: React.ReactNode;
   isSubmittable?: boolean;
+  isLong?: boolean;
 }
 
 interface ISplitProblemDetailPageTemplate extends IProblemDetailPageTemplate {
@@ -73,6 +75,8 @@ interface ISplitProblemDetailPageTemplate extends IProblemDetailPageTemplate {
   rightSideContent?: React.ReactNode;
   sizes?: number[];
   isSubmittable?: boolean;
+  isLong?: boolean;
+  getAnswerWithoutSubmit?: () => void;
 }
 
 export interface IMypageProblem {


### PR DESCRIPTION
### 작업 내역

> 구현 내용 및 작업 했던 내역

#### 서술형 문제 풀이 페이지 하단
<img width="375" alt="스크린샷 2022-11-18 오후 4 26 47" src="https://user-images.githubusercontent.com/63906230/202649800-4742fb0c-d267-4d2c-a99c-1d21879168b6.png">


#### 정답 보기 페이지
<img width="1636" alt="스크린샷 2022-11-18 오후 5 05 56" src="https://user-images.githubusercontent.com/63906230/202652042-3369c70b-3cd3-463b-b7f4-5d05f908a890.png">

- [x] 서술형 채점 버튼에 베타 태그 
- [x] 정답보기 기능
- [x] 서술형 채점 결과 평가 popover 버그 제거
- [x] 문제 목록 필터 라벨 클릭시 태그 삭제되지않는 버그 제거

### 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- grade API로 동작하게 구현해놓았고 추후에 request에 채점안한다는 flag만 넣어주도록 하겠습니다~!
