### PR TITLE
MSTR-419: 유저정보수정페이지 버그 수정

### DIFF
--- a/packages/service/src/Page/UserDataEditPage/index.tsx
+++ b/packages/service/src/Page/UserDataEditPage/index.tsx
@@ -28,7 +28,7 @@ export const UserDataEditPage = () => {
   const { data: profileData } = useQuery<IProfileData>(
     'getUserInfoData',
     () => userApiWrapper.getUserInfoData(myUserInfo.id),
-    { refetchOnWindowFocus: false, staleTime: 10000 },
+    { cacheTime: 0 },
   );
 
   const loadMajorOptions = (inputValue: string, callback: (options: IOption[]) => void) => {
@@ -63,7 +63,7 @@ export const UserDataEditPage = () => {
     callback(JOB_OBJECTIVE.filter((e) => e.label.includes(inputValue)));
   };
 
-  const [newProfileData, setNewProfileData] = useState<IProfileData | undefined>(profileData);
+  const [newProfileData, setNewProfileData] = useState<Partial<IProfileData>>();
 
   const submitProfileData = () => {
     userApiWrapper
@@ -105,9 +105,9 @@ export const UserDataEditPage = () => {
               loadOptions={loadMajorOptions}
               defaultValue={createOptions(profileData?.major ? [profileData.major] : [])}
               onChange={(majorOption: IOption) => {
-                setNewProfileData(
-                  newProfileData ? { ...newProfileData, major: majorOption.label } : undefined,
-                );
+                setNewProfileData((prev) => {
+                  return { ...prev, major: majorOption.label };
+                });
               }}
             />
             <DefaultSelect
@@ -117,9 +117,9 @@ export const UserDataEditPage = () => {
               loadOptions={loadJobOptions}
               defaultValue={JOB.find((e) => e.label === profileData?.job)}
               onChange={(jobOption: IOption) => {
-                setNewProfileData(
-                  newProfileData ? { ...newProfileData, job: jobOption.label } : undefined,
-                );
+                setNewProfileData((prev) => {
+                  return { ...prev, job: jobOption.label };
+                });
               }}
             />
             <DefaultSelect
@@ -128,11 +128,9 @@ export const UserDataEditPage = () => {
               isMulti={true}
               defaultValue={createOptions(profileData?.techs ? profileData.techs : [])}
               onChange={(techOptions: IOption[]) => {
-                setNewProfileData(
-                  newProfileData
-                    ? { ...newProfileData, techs: techOptions.map((e) => e.label) }
-                    : undefined,
-                );
+                setNewProfileData((prev) => {
+                  return { ...prev, techs: techOptions.map((e) => e.label) };
+                });
               }}
             />
             <DefaultSelect
@@ -142,9 +140,9 @@ export const UserDataEditPage = () => {
               loadOptions={loadJobObjectiveOptions}
               defaultValue={JOB_OBJECTIVE.find((e) => e.label === profileData?.jobObjective)}
               onChange={(jobOption: IOption) => {
-                setNewProfileData(
-                  newProfileData ? { ...newProfileData, jobObjective: jobOption.label } : undefined,
-                );
+                setNewProfileData((prev) => {
+                  return { ...prev, jobObjective: jobOption.label };
+                });
               }}
             />
             <UrlInputBox

--- a/packages/service/src/Page/UserDataEditPage/index.tsx
+++ b/packages/service/src/Page/UserDataEditPage/index.tsx
@@ -25,10 +25,8 @@ export const UserDataEditPage = () => {
   const myUserInfo = getUserInfo();
   if (!myUserInfo) return <></>;
   const navigate = useNavigate();
-  const { data: profileData } = useQuery<IProfileData>(
-    'getUserInfoData',
-    () => userApiWrapper.getUserInfoData(myUserInfo.id),
-    { cacheTime: 0 },
+  const { data: profileData } = useQuery<IProfileData>('getUserInfoData', () =>
+    userApiWrapper.getUserInfoData(myUserInfo.id),
   );
 
   const loadMajorOptions = (inputValue: string, callback: (options: IOption[]) => void) => {


### PR DESCRIPTION
### Issue Number

close: #419

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 실제로 수정이 안되는 버그
- [x] 수정사항이 화면에 바로 반영되지 않는 버그

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 버그1: useState에서 prev callback 사용하지않아서 발생 (useState는 클로저로 구현되어있기 때문)
- 버그2: React query의 stale time 옵션을 오해해서 발생
    - staleTime은 디폴트가 0이고 진짜진짜 정적인 데이터에 대해서만 설정해주면 된다.
    - cacheTime은 캐시를 유지하는 시간이고 디폴트로 일정한 시간이 있어 그대로 사용해도 된다.
