### PR TITLE
어드민 서술형문제 수정페이지에 "X"가 모범답안으로 추가되는 버그 수정

### DIFF
--- a/packages/admin/src/pages/problem/long/LongProblemEditPage.tsx
+++ b/packages/admin/src/pages/problem/long/LongProblemEditPage.tsx
@@ -87,7 +87,9 @@ export const LongProblemEditPage = () => {
       standardAnswers:
         Array.from(
           document.getElementsByClassName('standard-answer') as HTMLCollectionOf<HTMLInputElement>,
-        ).map((e) => e.value) || [],
+        )
+          .filter((e) => !e.ariaHidden)
+          .map((e) => e.value) || [],
       tags: tagState.filter((tag) => tag.isChecked).map((e) => e.id),
       gradingStandards: [
         ...keywordStandardState.map(({ content, score, type }) => {


### PR DESCRIPTION
MUI에서 aria-hidden으로 숨겨놓은 input이 있었음

### Issue Number

close: #444

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 어드민 서술형문제 수정페이지에 "X"가 모범답안으로 추가되는 버그 수정 (MUI에서 aria-hidden으로 숨겨놓은 input이 있었음)

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 모범답안 삭제 & 문제 활성화 안됨 이슈로 버그가 완벽히 수정되었는지 확인이 어려웠음 (그래도 된거같음)
